### PR TITLE
merging with interactive_marker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ include(${QT_USE_FILE})
 
 find_package(Boost REQUIRED COMPONENTS thread)
 include_directories(${Boost_INCLUDE_DIRS})
+add_definitions(--std=c++0x)
 
 # Build the RViz plugin.
 qt4_wrap_cpp(MOC_FILES 
@@ -44,6 +45,13 @@ add_library("${PROJECT_NAME}_rvizplugin" SHARED
     src/Plugins/EnvironmentDisplay.cpp
     src/Plugins/KinBodyVisual.cpp
     src/Plugins/LinkVisual.cpp
+    src/Markers/JointMarker.cpp
+    src/Markers/KinBodyJointMarker.cpp
+    src/Markers/KinBodyLinkMarker.cpp
+    src/Markers/KinBodyMarker.cpp
+    src/Markers/LinkMarker.cpp
+    src/Markers/ManipulatorMarker.cpp
+    src/or_conversions.cpp
     ${RVIZ_PLUGIN_FILES}
 )
 target_link_libraries("${PROJECT_NAME}_rvizplugin"

--- a/src/Markers/JointMarker.cpp
+++ b/src/Markers/JointMarker.cpp
@@ -1,0 +1,160 @@
+#include <boost/format.hpp>
+#include <openrave/openrave.h>
+#include <openrave/geometry.h>
+#include <interactive_markers/interactive_marker_server.h>
+#include "JointMarker.h"
+#include "../or_conversions.h"
+
+using boost::format;
+using boost::str;
+using interactive_markers::InteractiveMarkerServer;
+using visualization_msgs::InteractiveMarkerControl;
+using visualization_msgs::InteractiveMarkerFeedback;
+using visualization_msgs::InteractiveMarkerFeedbackConstPtr;
+using OpenRAVE::dReal;
+using OpenRAVE::KinBody;
+using OpenRAVE::KinBodyPtr;
+
+typedef boost::shared_ptr<InteractiveMarkerServer> InteractiveMarkerServerPtr;
+typedef OpenRAVE::KinBody::JointPtr JointPtr;
+
+// TODO: Don't hardcode this.
+static std::string const kWorldFrameId = "/map";
+
+namespace or_interactivemarker
+{
+
+    JointMarker::JointMarker(InteractiveMarkerServerPtr server, JointPtr joint) :
+            server_(server), joint_(joint), joint_delta_(0.0), created_(false), active_(false)
+    {
+        BOOST_ASSERT(joint);
+
+        // TODO: Support more types of joints.
+        if (joint->GetType() != OpenRAVE::KinBody::JointRevolute)
+        {
+            return;
+        }
+
+        // Ignore static and mimic joints since we can't directly control them.
+        if (joint->IsStatic())
+        {
+            return;
+        }
+        else if (joint->IsMimic())
+        {
+            return;
+        }
+
+        marker_.header.frame_id = kWorldFrameId;
+        marker_.name = id();
+        marker_.description = "";
+        marker_.pose = toROSPose(pose());
+        // TODO: Infer a good scale for the control.
+        marker_.scale = 0.25;
+
+        InteractiveMarkerControl control;
+        // TODO: Why isn't this rotation about the x-axis?
+        control.orientation.w = 1;
+        control.orientation.x = 0;
+        control.orientation.y = 1;
+        control.orientation.z = 0;
+        control.name = "rotate";
+        control.interaction_mode = InteractiveMarkerControl::ROTATE_AXIS;
+        marker_.controls.push_back(control);
+
+        server_->insert(marker_);
+        server_->setCallback(marker_.name, boost::bind(&JointMarker::JointCallback, this, _1));
+    }
+
+    JointMarker::~JointMarker()
+    {
+        server_->erase(marker_.name);
+    }
+
+    std::string JointMarker::id() const
+    {
+        JointPtr const joint = this->joint();
+        OpenRAVE::KinBodyPtr const body = joint->GetParent();
+        OpenRAVE::EnvironmentBasePtr const env = body->GetEnv();
+        int const environment_id = OpenRAVE::RaveGetEnvironmentId(env);
+
+        return str(format("Environment[%d].KinBody[%s].Joint[%s]") % environment_id % body->GetName() % joint->GetName());
+    }
+
+    JointPtr JointMarker::joint() const
+    {
+        return joint_.lock();
+    }
+
+    OpenRAVE::Transform JointMarker::pose() const
+    {
+        return joint_pose_;
+    }
+
+    void JointMarker::set_pose(OpenRAVE::Transform const &pose)
+    {
+        if (!active_)
+        {
+            joint_pose_ = pose;
+        }
+    }
+
+    double JointMarker::angle() const
+    {
+        return joint_initial_ + joint_delta_;
+    }
+
+    bool JointMarker::EnvironmentSync()
+    {
+        // Update the pose of the marker.
+        if (created_)
+        {
+            server_->setPose(marker_.name, toROSPose(pose()));
+        }
+        if (!active_)
+        {
+            joint_initial_ = joint()->GetValue(0);
+            joint_delta_ = 0;
+        }
+
+        created_ = true;
+        return false;
+    }
+
+    void JointMarker::JointCallback(InteractiveMarkerFeedbackConstPtr const &feedback)
+    {
+        if (feedback->event_type == InteractiveMarkerFeedback::MOUSE_DOWN)
+        {
+            active_ = true;
+        }
+        else if (feedback->event_type == InteractiveMarkerFeedback::MOUSE_UP)
+        {
+            active_ = false;
+        }
+        else if (feedback->event_type == InteractiveMarkerFeedback::POSE_UPDATE)
+        {
+            // Get the pose of the handle relative to the current joint position.
+            // TODO: Why is this a rotation about the z-axis? It should be the y-axis.
+            try
+            {
+                OpenRAVE::Transform const pose = this->pose().inverse() * toORPose < dReal > (feedback->pose);
+                OpenRAVE::Vector const axis_angle = OpenRAVE::geometry::axisAngleFromQuat(pose.rot);
+
+                // TODO: Why is this negated?
+                joint_delta_ = -axis_angle[2];
+            }
+            catch (OpenRAVE::openrave_exception& exception)
+            {
+                RAVELOG_WARN(exception.what());
+            }
+        }
+    }
+
+    OpenRAVE::Transform JointMarker::GetJointPose(JointPtr joint)
+    {
+        OpenRAVE::Transform pose = OpenRAVE::geometry::transformLookat(OpenRAVE::Vector(0, 0, 0), joint->GetAxis(), OpenRAVE::Vector(1, 0, 0));
+        pose.trans = joint->GetAnchor();
+        return pose;
+    }
+
+}

--- a/src/Markers/JointMarker.h
+++ b/src/Markers/JointMarker.h
@@ -1,0 +1,50 @@
+#ifndef JOINTMARKER_H_
+#define JOINTMARKER_H_
+#include <openrave/openrave.h>
+#include <interactive_markers/interactive_marker_server.h>
+
+namespace or_interactivemarker
+{
+
+    class JointMarker;
+    typedef boost::shared_ptr<JointMarker> JointMarkerPtr;
+
+    class JointMarker
+    {
+        public:
+            JointMarker(boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server, OpenRAVE::KinBody::JointPtr joint);
+            virtual ~JointMarker();
+
+            std::string id() const;
+            OpenRAVE::KinBody::JointPtr joint() const;
+
+            OpenRAVE::Transform pose() const;
+            void set_pose(OpenRAVE::Transform const &pose);
+
+            double angle() const;
+
+            void set_joint_pose(OpenRAVE::Transform const &pose);
+
+            virtual bool EnvironmentSync();
+
+            static OpenRAVE::Transform GetJointPose(OpenRAVE::KinBody::JointPtr joint);
+
+        protected:
+            boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
+            visualization_msgs::InteractiveMarker marker_;
+            visualization_msgs::InteractiveMarkerControl *joint_control_;
+
+        private:
+            OpenRAVE::KinBody::JointWeakPtr joint_;
+            OpenRAVE::Transform joint_pose_;
+            double joint_initial_;
+            double joint_delta_;
+            bool created_;
+            bool active_;
+
+            void JointCallback(visualization_msgs::InteractiveMarkerFeedbackConstPtr const &feedback);
+    };
+
+}
+
+#endif

--- a/src/Markers/KinBodyJointMarker.cpp
+++ b/src/Markers/KinBodyJointMarker.cpp
@@ -1,0 +1,43 @@
+#include "KinBodyJointMarker.h"
+
+using interactive_markers::InteractiveMarkerServer;
+using OpenRAVE::KinBody;
+using OpenRAVE::KinBodyPtr;
+
+typedef boost::shared_ptr<InteractiveMarkerServer> InteractiveMarkerServerPtr;
+typedef OpenRAVE::KinBody::JointPtr JointPtr;
+
+namespace or_interactivemarker
+{
+
+    KinBodyJointMarker::KinBodyJointMarker(InteractiveMarkerServerPtr server, JointPtr joint) :
+            JointMarker(server, joint)
+    {
+    }
+
+    KinBodyJointMarker::~KinBodyJointMarker()
+    {
+    }
+
+    bool KinBodyJointMarker::EnvironmentSync()
+    {
+        // Update the KinBody in the OpenRAVE environment.
+        JointPtr const joint = this->joint();
+        KinBodyPtr const kinbody = joint->GetParent();
+        std::vector<int> dof_indices;
+        std::vector<OpenRAVE::dReal> dof_values;
+        dof_indices.push_back(joint->GetJointIndex());
+        kinbody->GetDOFValues(dof_values, dof_indices);
+        BOOST_ASSERT(joint->GetDOF() == 1);
+        BOOST_ASSERT(dof_values.size() == 1);
+
+        dof_values[0] = angle();
+        kinbody->SetDOFValues(dof_values, KinBody::CLA_CheckLimitsSilent, dof_indices);
+
+        // Update the pose of the joint from OpenRAVE.
+        set_pose(GetJointPose(joint));
+
+        return JointMarker::EnvironmentSync();
+    }
+
+}

--- a/src/Markers/KinBodyJointMarker.h
+++ b/src/Markers/KinBodyJointMarker.h
@@ -1,0 +1,24 @@
+#ifndef KINBODYJOINTMARKER_H_
+#define KINBODYJOINTMARKER_H_
+#include <openrave/openrave.h>
+#include <interactive_markers/interactive_marker_server.h>
+#include "JointMarker.h"
+
+namespace or_interactivemarker
+{
+
+    class KinBodyJointMarker;
+    typedef boost::shared_ptr<KinBodyJointMarker> KinBodyJointMarkerPtr;
+
+    class KinBodyJointMarker: public JointMarker
+    {
+        public:
+            KinBodyJointMarker(boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server, OpenRAVE::KinBody::JointPtr joint);
+            virtual ~KinBodyJointMarker();
+
+            virtual bool EnvironmentSync();
+    };
+
+}
+
+#endif

--- a/src/Markers/KinBodyLinkMarker.cpp
+++ b/src/Markers/KinBodyLinkMarker.cpp
@@ -1,0 +1,148 @@
+#include "KinBodyLinkMarker.h"
+#include "../or_conversions.h"
+
+using interactive_markers::MenuHandler;
+using visualization_msgs::InteractiveMarkerFeedbackConstPtr;
+
+typedef OpenRAVE::KinBody::LinkPtr LinkPtr;
+typedef OpenRAVE::KinBody::LinkInfo LinkInfo;
+
+static MenuHandler::CheckState BoolToCheckState(bool const &flag)
+{
+    if (flag)
+    {
+        return MenuHandler::CHECKED;
+    }
+    else
+    {
+        return MenuHandler::UNCHECKED;
+    }
+}
+
+static bool CheckStateToBool(MenuHandler::CheckState const &state)
+{
+    return state == MenuHandler::CHECKED;
+}
+
+namespace or_interactivemarker
+{
+
+    KinBodyLinkMarker::KinBodyLinkMarker(boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server, OpenRAVE::KinBody::LinkPtr link) :
+            LinkMarker(server, link, false)
+    {
+        CreateMenu();
+    }
+
+    interactive_markers::MenuHandler &KinBodyLinkMarker::menu_handler()
+    {
+        return menu_handler_;
+    }
+
+    bool KinBodyLinkMarker::EnvironmentSync()
+    {
+        bool const is_changed = LinkMarker::EnvironmentSync();
+
+        OpenRAVE::Transform const link_pose = link()->GetTransform();
+        set_pose(link_pose);
+
+        if (is_changed)
+        {
+            UpdateMenu();
+        }
+
+        return is_changed;
+    }
+
+    void KinBodyLinkMarker::CreateMenu()
+    {
+        auto const callback = boost::bind(&KinBodyLinkMarker::MenuCallback, this, _1);
+
+        menu_link_ = menu_handler_.insert("Link", callback);
+        menu_enabled_ = menu_handler_.insert(menu_link_, "Enabled", callback);
+        menu_visible_ = menu_handler_.insert(menu_link_, "Visible", callback);
+
+        // Switching geometry mode.
+        menu_geom_ = menu_handler_.insert(menu_link_, "Geometry");
+        menu_geom_visual_ = menu_handler_.insert(menu_geom_, "Visual", callback);
+        menu_geom_collision_ = menu_handler_.insert(menu_geom_, "Collision", callback);
+        menu_geom_both_ = menu_handler_.insert(menu_geom_, "Both", callback);
+        menu_changed_ = true;
+
+        // Switching geometry groups.
+        menu_groups_ = menu_handler_.insert(menu_link_, "Geometry Groups");
+        menu_groups_entries_.clear();
+
+        for (std::string const group_name : group_names())
+        {
+            auto const callback = boost::bind(&KinBodyLinkMarker::SwitchGeometryGroup, this, group_name);
+            menu_groups_entries_[group_name] = menu_handler_.insert(menu_groups_, group_name, callback);
+        }
+    }
+
+    void KinBodyLinkMarker::UpdateMenu()
+    {
+        LinkPtr const link = this->link();
+
+        menu_handler_.setCheckState(menu_enabled_, BoolToCheckState(link->IsEnabled()));
+        menu_handler_.setCheckState(menu_visible_, BoolToCheckState(link->IsVisible()));
+        menu_handler_.setCheckState(menu_geom_visual_, BoolToCheckState(is_view_visual() && !is_view_collision()));
+        menu_handler_.setCheckState(menu_geom_collision_, BoolToCheckState(!is_view_visual() && is_view_collision()));
+        menu_handler_.setCheckState(menu_geom_both_, BoolToCheckState(is_view_visual() && is_view_collision()));
+
+        menu_handler_.apply(*server_, interactive_marker_->name);
+        menu_changed_ = false;
+    }
+
+    void KinBodyLinkMarker::MenuCallback(InteractiveMarkerFeedbackConstPtr const &feedback)
+    {
+        LinkPtr const link = this->link();
+
+        // Toggle collision detection.
+        if (feedback->menu_entry_id == menu_enabled_)
+        {
+            MenuHandler::CheckState enabled_state;
+            menu_handler_.getCheckState(menu_enabled_, enabled_state);
+
+            bool const is_enabled = !CheckStateToBool(enabled_state);
+            link->Enable(is_enabled);
+
+            RAVELOG_DEBUG("Toggled enable to %d for '%s' link '%s'.\n", is_enabled, link->GetParent()->GetName().c_str(), link->GetName().c_str());
+        }
+        // Toggle visiblity.
+        else if (feedback->menu_entry_id == menu_visible_)
+        {
+            MenuHandler::CheckState visible_state;
+            menu_handler_.getCheckState(menu_visible_, visible_state);
+
+            bool const is_visible = !CheckStateToBool(visible_state);
+            link->SetVisible(is_visible);
+
+            RAVELOG_DEBUG("Toggled visible to %d for '%s' link '%s'.\n", is_visible, link->GetParent()->GetName().c_str(), link->GetName().c_str());
+        }
+        // Geometry rendering mode.
+        else if (feedback->menu_entry_id == menu_geom_visual_)
+        {
+            set_view_visual(true);
+            set_view_collision(false);
+            RAVELOG_DEBUG("Showing visual geometry for '%s' link '%s'.\n", link->GetParent()->GetName().c_str(), link->GetName().c_str());
+        }
+        else if (feedback->menu_entry_id == menu_geom_collision_)
+        {
+            set_view_visual(false);
+            set_view_collision(true);
+            RAVELOG_DEBUG("Showing collision geometry for '%s' link '%s'.\n", link->GetParent()->GetName().c_str(), link->GetName().c_str());
+        }
+        else if (feedback->menu_entry_id == menu_geom_both_)
+        {
+            set_view_visual(true);
+            set_view_collision(true);
+            RAVELOG_DEBUG("Showing visual and collision geometry for '%s' link '%s'.\n", link->GetParent()->GetName().c_str(), link->GetName().c_str());
+        }
+
+        // TODO: Should we applyChanges here?
+        UpdateMenu();
+        server_->applyChanges();
+    }
+
+}
+

--- a/src/Markers/KinBodyLinkMarker.h
+++ b/src/Markers/KinBodyLinkMarker.h
@@ -1,0 +1,44 @@
+#ifndef KINBODYLINKMARKER_H_
+#define KINBODYLINKMARKER_H_
+#include <interactive_markers/interactive_marker_server.h>
+#include "LinkMarker.h"
+
+namespace or_interactivemarker
+{
+
+    class KinBodyLinkMarker;
+    typedef boost::shared_ptr<KinBodyLinkMarker> KinBodyLinkMarkerPtr;
+
+    class KinBodyLinkMarker: public LinkMarker
+    {
+        public:
+            KinBodyLinkMarker(boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server, OpenRAVE::KinBody::LinkPtr link);
+
+            interactive_markers::MenuHandler &menu_handler();
+
+            virtual bool EnvironmentSync();
+            void UpdateMenu();
+
+        private:
+            typedef interactive_markers::MenuHandler MenuHandler;
+
+            bool menu_changed_;
+            std::vector<visualization_msgs::MenuEntry> menu_entries_;
+            MenuHandler menu_handler_;
+            MenuHandler::EntryHandle menu_link_;
+            MenuHandler::EntryHandle menu_visible_;
+            MenuHandler::EntryHandle menu_enabled_;
+            MenuHandler::EntryHandle menu_geom_;
+            MenuHandler::EntryHandle menu_geom_visual_;
+            MenuHandler::EntryHandle menu_geom_collision_;
+            MenuHandler::EntryHandle menu_geom_both_;
+            MenuHandler::EntryHandle menu_groups_;
+            boost::unordered_map<std::string, MenuHandler::EntryHandle> menu_groups_entries_;
+
+            void CreateMenu();
+            void MenuCallback(visualization_msgs::InteractiveMarkerFeedbackConstPtr const &feedback);
+    };
+
+}
+
+#endif

--- a/src/Markers/KinBodyMarker.cpp
+++ b/src/Markers/KinBodyMarker.cpp
@@ -1,0 +1,549 @@
+#include <boost/format.hpp>
+#include <boost/make_shared.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/range/adaptor/map.hpp>
+#include "KinBodyMarker.h"
+#include "../or_conversions.h"
+
+using boost::ref;
+using boost::format;
+using boost::str;
+using boost::algorithm::ends_with;
+using boost::adaptors::map_values;
+using OpenRAVE::dReal;
+using OpenRAVE::EnvironmentBasePtr;
+using OpenRAVE::KinBodyPtr;
+using OpenRAVE::KinBodyWeakPtr;
+using OpenRAVE::RobotBase;
+using OpenRAVE::RobotBaseWeakPtr;
+using visualization_msgs::InteractiveMarker;
+using visualization_msgs::InteractiveMarkerControl;
+using visualization_msgs::InteractiveMarkerFeedback;
+using visualization_msgs::InteractiveMarkerFeedbackConstPtr;
+using interactive_markers::InteractiveMarkerServer;
+using interactive_markers::MenuHandler;
+
+typedef OpenRAVE::KinBody::LinkPtr LinkPtr;
+typedef OpenRAVE::KinBody::JointPtr JointPtr;
+typedef OpenRAVE::RobotBase::ManipulatorPtr ManipulatorPtr;
+typedef boost::shared_ptr<InteractiveMarkerServer> InteractiveMarkerServerPtr;
+typedef MenuHandler::EntryHandle EntryHandle;
+
+static std::string const kWorldFrameId = "/map";
+
+namespace or_interactivemarker
+{
+
+// TODO: Move this to a helper header.
+    static MenuHandler::CheckState BoolToCheckState(bool const &flag)
+    {
+        if (flag)
+        {
+            return MenuHandler::CHECKED;
+        }
+        else
+        {
+            return MenuHandler::UNCHECKED;
+        }
+    }
+
+    static bool CheckStateToBool(MenuHandler::CheckState const &state)
+    {
+        return state == MenuHandler::CHECKED;
+    }
+
+    KinBodyMarker::KinBodyMarker(InteractiveMarkerServerPtr server, KinBodyPtr kinbody) :
+            server_(server), kinbody_(kinbody), robot_(boost::dynamic_pointer_cast<RobotBase>(kinbody)), has_pose_controls_(false), has_joint_controls_(false), new_marker_(false)
+    {
+        BOOST_ASSERT(server);
+        BOOST_ASSERT(kinbody);
+
+        EnablePoseControls(false);
+
+#if 0
+#endif
+    }
+
+    KinBodyMarker::~KinBodyMarker()
+    {
+        if (interactive_marker_)
+        {
+            server_->erase(interactive_marker_->name);
+        }
+    }
+
+    std::string KinBodyMarker::id() const
+    {
+        KinBodyPtr const body = kinbody_.lock();
+        EnvironmentBasePtr const env = body->GetEnv();
+        int const environment_id = OpenRAVE::RaveGetEnvironmentId(env);
+        return str(format("Environment[%d].KinBody[%s]") % environment_id % body->GetName());
+    }
+
+    std::vector<std::string> KinBodyMarker::group_names() const
+    {
+        std::set<std::string> all_group_names;
+
+        for (LinkMarkerWrapper const &wrapper : link_markers_ | map_values)
+        {
+            std::vector<std::string> const link_group_names = wrapper.link_marker->group_names();
+            all_group_names.insert(link_group_names.begin(), link_group_names.end());
+        }
+
+        return std::vector<std::string>(all_group_names.begin(), all_group_names.end());
+    }
+
+    void KinBodyMarker::SwitchGeometryGroup(std::string const &group)
+    {
+        // This is theoretically more efficient than calling SetGeometriesFromGroup
+        // on each link. See the OpenRAVE documentation for more information.
+        kinbody_.lock()->SetLinkGeometriesFromGroup(group);
+    }
+
+    void KinBodyMarker::AddMenuEntry(std::string const &name, boost::function<void()> const &callback)
+    {
+        CustomMenuEntry entry;
+        entry.name = name;
+        entry.callback = callback;
+        menu_custom_kinbody_.push_back(entry);
+
+        RAVELOG_DEBUG("Added menu option [ KinBody > %s ] to KinBody '%s'.\n", name.c_str(), kinbody_.lock()->GetName().c_str());
+
+        // TODO: Only re-generate the menu.
+        link_markers_.clear();
+    }
+
+    void KinBodyMarker::AddMenuEntry(LinkPtr link, std::string const &name, boost::function<void()> const &callback)
+    {
+        CustomMenuEntry entry;
+        entry.name = name;
+        entry.callback = callback;
+
+        menu_custom_links_[link.get()].push_back(entry);
+
+        RAVELOG_DEBUG("Added menu option [ Link > %s ] to KinBody '%s' link '%s'.\n", name.c_str(), kinbody_.lock()->GetName().c_str(), link->GetName().c_str());
+
+        // TODO: Only re-generate the menu.
+        link_markers_.clear();
+    }
+
+    void KinBodyMarker::AddMenuEntry(ManipulatorPtr manipulator, std::string const &name, boost::function<void()> const &callback)
+    {
+        CustomMenuEntry entry;
+        entry.name = name;
+        entry.callback = callback;
+        menu_custom_manipulators_[manipulator.get()].push_back(entry);
+
+        RAVELOG_DEBUG("Added menu option [ Manipulator > %s ] to KinBody '%s' manipulator '%s'.\n", name.c_str(), kinbody_.lock()->GetName().c_str(), manipulator->GetName().c_str());
+
+        // TODO: Only re-generate the menu.
+        link_markers_.clear();
+    }
+
+    void KinBodyMarker::EnvironmentSync()
+    {
+        typedef OpenRAVE::KinBody::LinkPtr LinkPtr;
+        typedef OpenRAVE::KinBody::JointPtr JointPtr;
+
+        KinBodyPtr const kinbody = kinbody_.lock();
+
+        // Update the KinBody's marker.
+        if (interactive_marker_ && !new_marker_)
+        {
+            OpenRAVE::Transform const kinbody_pose = kinbody->GetTransform();
+            server_->setPose(interactive_marker_->name, toROSPose(kinbody_pose));
+        }
+        new_marker_ = false;
+
+        // Update links. This includes the geometry of the KinBody.
+        for (LinkPtr link : kinbody->GetLinks())
+        {
+            LinkMarkerWrapper &wrapper = link_markers_[link.get()];
+            KinBodyLinkMarkerPtr &link_marker = wrapper.link_marker;
+            if (!link_marker)
+            {
+                link_marker = boost::make_shared<KinBodyLinkMarker>(server_, link);
+                CreateMenu(wrapper);
+                UpdateMenu(wrapper);
+            }
+            link_marker->EnvironmentSync();
+        }
+
+        // Update joints.
+        for (JointPtr joint : kinbody->GetJoints())
+        {
+            auto const it = joint_markers_.find(joint.get());
+            if (it == joint_markers_.end())
+            {
+                continue;
+            }
+            KinBodyJointMarkerPtr &joint_marker = it->second;
+
+            // Lazily construct a new marker if necessary.
+            if (!joint_marker)
+            {
+                joint_marker = boost::make_shared<KinBodyJointMarker>(server_, joint);
+            }
+            joint_marker->EnvironmentSync();
+        }
+
+        // Update manipulators.
+        for (ManipulatorMarkerPtr const &manipulator_marker : manipulator_markers_ | map_values)
+        {
+            manipulator_marker->EnvironmentSync();
+        }
+    }
+
+    void KinBodyMarker::CreateMenu(LinkMarkerWrapper &link_wrapper)
+    {
+        typedef boost::optional<EntryHandle> Opt;
+
+        BOOST_ASSERT(!link_wrapper.has_menu);
+        auto const cb = boost::bind(&KinBodyMarker::MenuCallback, this, ref(link_wrapper), _1);
+        MenuHandler &menu_handler = link_wrapper.link_marker->menu_handler();
+
+        // KinBody controls.
+        {
+            EntryHandle parent = menu_handler.insert("Body");
+            link_wrapper.menu_parent = Opt(parent);
+            link_wrapper.menu_enabled = Opt(menu_handler.insert(parent, "Enabled", cb));
+            link_wrapper.menu_visible = Opt(menu_handler.insert(parent, "Visible", cb));
+            link_wrapper.menu_move = Opt(menu_handler.insert(parent, "Pose Controls", cb));
+            link_wrapper.menu_joints = Opt(menu_handler.insert(parent, "Joint Controls", cb));
+
+            EntryHandle geom_parent = menu_handler.insert(parent, "Geometry");
+            link_wrapper.menu_geometry = Opt(geom_parent);
+            link_wrapper.menu_geometry_visual = Opt(menu_handler.insert(geom_parent, "Visual", cb));
+            link_wrapper.menu_geometry_collision = Opt(menu_handler.insert(geom_parent, "Collision", cb));
+            link_wrapper.menu_geometry_both = Opt(menu_handler.insert(geom_parent, "Both", cb));
+
+            // Geometry groups.
+            EntryHandle groups_parent = menu_handler.insert(parent, "Geometry Groups");
+            link_wrapper.menu_groups = Opt(groups_parent);
+
+            link_wrapper.menu_groups_entries.clear();
+            for (std::string const &group_name : group_names())
+            {
+                // TODO: Add a callback.
+                auto const group_cb = boost::bind(&KinBodyMarker::SwitchGeometryGroup, this, group_name);
+                EntryHandle const group_handle = menu_handler.insert(groups_parent, group_name, group_cb);
+                link_wrapper.menu_groups_entries[group_name] = group_handle;
+            }
+
+            // Custom KinBody entries.
+            for (CustomMenuEntry const &menu_entry : menu_custom_kinbody_)
+            {
+                auto const custom_cb = boost::bind(menu_entry.callback);
+                menu_handler.insert(parent, menu_entry.name, custom_cb);
+            }
+        }
+
+        // Custom link entries.
+        {
+            LinkPtr const link = link_wrapper.link_marker->link();
+            std::vector<CustomMenuEntry> const &entries = menu_custom_links_[link.get()];
+            for (CustomMenuEntry const &menu_entry : entries)
+            {
+                // TODO: Add a custom callback.
+                // TODO: Put these in the "Link" submenu.
+                menu_handler.insert("LINK: " + menu_entry.name);
+            }
+        }
+
+        // Manipulator controls. For now, we'll only add these options to links
+        // that unambiguously belong to one manipulator.
+        // TODO: Move this elsewhere.
+        std::vector<ManipulatorPtr> manipulators;
+        GetManipulators(link_wrapper.link_marker->link(), &manipulators);
+        if (manipulators.size() == 1)
+        {
+            link_wrapper.parent_manipulator = manipulators.front();
+        }
+
+        if (link_wrapper.parent_manipulator)
+        {
+            EntryHandle parent = menu_handler.insert("Manipulator");
+            link_wrapper.menu_manipulator = Opt(parent);
+            // TODO: Implement joint control on the ghost manipulator.
+            //link_wrapper.menu_manipulator_joints = Opt(menu_handler.insert(parent, "Joint Controls", cb));
+            link_wrapper.menu_manipulator_active = Opt(menu_handler.insert(parent, "Set Active", cb));
+            link_wrapper.menu_manipulator_ik = Opt(menu_handler.insert(parent, "Inverse Kinematics", cb));
+
+            // Custom manipulator entries.
+            std::vector<CustomMenuEntry> const &entries = menu_custom_manipulators_[link_wrapper.parent_manipulator.get()];
+            for (CustomMenuEntry const &menu_entry : entries)
+            {
+                // TODO: Add a custom callback.
+                menu_handler.insert(parent, menu_entry.name);
+            }
+        }
+        link_wrapper.has_menu = true;
+    }
+
+    void KinBodyMarker::UpdateMenu()
+    {
+        for (LinkMarkerWrapper &marker_wrapper : link_markers_ | map_values)
+        {
+            UpdateMenu(marker_wrapper);
+            marker_wrapper.link_marker->UpdateMenu();
+            // TODO: How can the link notify us that our menu changed?
+        }
+    }
+
+    void KinBodyMarker::UpdateMenu(LinkMarkerWrapper &link_wrapper)
+    {
+        if (!link_wrapper.has_menu)
+        {
+            return;
+        }
+
+        MenuHandler &menu_handler = link_wrapper.link_marker->menu_handler();
+        LinkPtr const link = link_wrapper.link_marker->link();
+
+        menu_handler.setCheckState(*link_wrapper.menu_enabled, BoolToCheckState(link->IsEnabled()));
+        menu_handler.setCheckState(*link_wrapper.menu_visible, BoolToCheckState(link->IsVisible()));
+        menu_handler.setCheckState(*link_wrapper.menu_move, BoolToCheckState(has_pose_controls_));
+        menu_handler.setCheckState(*link_wrapper.menu_joints, BoolToCheckState(has_joint_controls_));
+
+        if (link_wrapper.menu_manipulator_ik)
+        {
+            bool const has_ghost = HasGhostManipulator(link_wrapper.parent_manipulator);
+            menu_handler.setCheckState(*link_wrapper.menu_manipulator_ik, BoolToCheckState(has_ghost));
+        }
+    }
+
+    void KinBodyMarker::MenuCallback(LinkMarkerWrapper &link_wrapper, InteractiveMarkerFeedbackConstPtr const &feedback)
+    {
+        MenuHandler &menu_handler = link_wrapper.link_marker->menu_handler();
+        KinBodyPtr kinbody = kinbody_.lock();
+        boost::recursive_mutex::scoped_lock lock(kinbody->GetEnv()->GetMutex());
+
+        // Toggle kinbody collision checking.
+        if (feedback->menu_entry_id == *link_wrapper.menu_enabled)
+        {
+            MenuHandler::CheckState enabled_state;
+            menu_handler.getCheckState(*link_wrapper.menu_enabled, enabled_state);
+            bool const is_enabled = !CheckStateToBool(enabled_state);
+            kinbody->Enable(is_enabled);
+            RAVELOG_DEBUG("Toggled enable to %d for '%s'.\n", is_enabled, kinbody->GetName().c_str());
+        }
+        // Toggle kinbody visibility.
+        else if (feedback->menu_entry_id == *link_wrapper.menu_visible)
+        {
+            MenuHandler::CheckState visible_state;
+            menu_handler.getCheckState(*link_wrapper.menu_visible, visible_state);
+            bool const is_visible = !CheckStateToBool(visible_state);
+            kinbody->SetVisible(is_visible);
+            RAVELOG_DEBUG("Toggled visible to %d for '%s'.\n", is_visible, kinbody->GetName().c_str());
+        }
+        // Change geometry visibility.
+        else if (feedback->menu_entry_id == *link_wrapper.menu_geometry_visual)
+        {
+            for (LinkMarkerWrapper &link_wrapper : link_markers_ | map_values)
+            {
+                link_wrapper.link_marker->set_view_visual(true);
+                link_wrapper.link_marker->set_view_collision(false);
+            }
+        }
+        else if (feedback->menu_entry_id == *link_wrapper.menu_geometry_collision)
+        {
+            for (LinkMarkerWrapper &link_wrapper : link_markers_ | map_values)
+            {
+                link_wrapper.link_marker->set_view_visual(false);
+                link_wrapper.link_marker->set_view_collision(true);
+            }
+        }
+        else if (feedback->menu_entry_id == *link_wrapper.menu_geometry_both)
+        {
+            for (LinkMarkerWrapper &link_wrapper : link_markers_ | map_values)
+            {
+                link_wrapper.link_marker->set_view_visual(true);
+                link_wrapper.link_marker->set_view_collision(true);
+            }
+        }
+        // Toggle movement handles.
+        else if (feedback->menu_entry_id == *link_wrapper.menu_move)
+        {
+            MenuHandler::CheckState move_state;
+            menu_handler.getCheckState(*link_wrapper.menu_move, move_state);
+            has_pose_controls_ = !CheckStateToBool(move_state);
+
+            EnablePoseControls(has_pose_controls_);
+
+            RAVELOG_DEBUG("Toggled pose controls to %d for '%s'.\n", has_pose_controls_, kinbody->GetName().c_str());
+        }
+        // Toggle full-KinBody joint controls.
+        else if (feedback->menu_entry_id == *link_wrapper.menu_joints)
+        {
+            MenuHandler::CheckState joints_state;
+            menu_handler.getCheckState(*link_wrapper.menu_joints, joints_state);
+            has_joint_controls_ = !CheckStateToBool(joints_state);
+            if (!has_joint_controls_)
+            {
+                joint_markers_.clear();
+            }
+            // Allocate space for all joint controls. The actual controls will be
+            // lazily created in the next EnvironmentSync callback.
+            else
+            {
+                for (JointPtr const &joint : kinbody->GetJoints())
+                {
+                    // Accessing an element causes it to be default-constructed.
+                    joint_markers_[joint.get()];
+                }
+            }
+
+            RAVELOG_DEBUG("Toggled joint controls to %d for '%s'.\n", has_joint_controls_, kinbody->GetName().c_str());
+        }
+        // Set the manipulator as active.
+        else if (link_wrapper.menu_manipulator_active && feedback->menu_entry_id == link_wrapper.menu_manipulator_active)
+        {
+            ManipulatorPtr const manipulator = link_wrapper.parent_manipulator;
+            manipulator->GetRobot()->SetActiveManipulator(manipulator);
+            RAVELOG_DEBUG("Set manipulator '%s' active for '%s'.\n", manipulator->GetName().c_str(), kinbody->GetName().c_str());
+        }
+        // Toggle manipulator IK control.
+        else if (link_wrapper.menu_manipulator_ik && feedback->menu_entry_id == link_wrapper.menu_manipulator_ik)
+        {
+            ManipulatorPtr const manipulator = link_wrapper.parent_manipulator;
+            BOOST_ASSERT(manipulator);
+
+            bool const ik_enabled = !HasGhostManipulator(manipulator);
+            if (ik_enabled)
+            {
+                ManipulatorMarkerPtr &manipulator_marker = manipulator_markers_[manipulator.get()];
+                if (!manipulator_marker)
+                {
+                    manipulator_marker = boost::make_shared<ManipulatorMarker>(server_, manipulator);
+                }
+            }
+            else
+            {
+                manipulator_markers_.erase(manipulator.get());
+            }
+
+            RAVELOG_DEBUG("Toggled IK control to %d for '%s' manipulator '%s'.\n", ik_enabled, kinbody->GetName().c_str(), manipulator->GetName().c_str());
+        }
+
+        UpdateMenu();
+    }
+
+    void KinBodyMarker::EnablePoseControls(bool enabled)
+    {
+        if (enabled)
+        {
+            OpenRAVE::KinBodyPtr const kinbody = kinbody_.lock();
+
+            interactive_marker_ = boost::make_shared<InteractiveMarker>();
+            interactive_marker_->header.frame_id = kWorldFrameId;
+            interactive_marker_->name = id();
+            interactive_marker_->description = "";
+            interactive_marker_->pose = toROSPose(kinbody->GetTransform());
+            interactive_marker_->scale = 1.0; // TODO: Infer a good scale.
+
+            InteractiveMarkerControl control;
+            control.orientation.w = 1;
+            control.orientation.x = 1;
+            control.orientation.y = 0;
+            control.orientation.z = 0;
+            control.name = "rotate_x";
+            control.interaction_mode = InteractiveMarkerControl::ROTATE_AXIS;
+            interactive_marker_->controls.push_back(control);
+            control.name = "move_x";
+            control.interaction_mode = InteractiveMarkerControl::MOVE_AXIS;
+            interactive_marker_->controls.push_back(control);
+
+            control.orientation.w = 1;
+            control.orientation.x = 0;
+            control.orientation.y = 1;
+            control.orientation.z = 0;
+            control.name = "rotate_z";
+            control.interaction_mode = InteractiveMarkerControl::ROTATE_AXIS;
+            interactive_marker_->controls.push_back(control);
+            control.name = "move_z";
+            control.interaction_mode = InteractiveMarkerControl::MOVE_AXIS;
+            interactive_marker_->controls.push_back(control);
+
+            control.orientation.w = 1;
+            control.orientation.x = 0;
+            control.orientation.y = 0;
+            control.orientation.z = 1;
+            control.name = "rotate_y";
+            control.interaction_mode = InteractiveMarkerControl::ROTATE_AXIS;
+            interactive_marker_->controls.push_back(control);
+            control.name = "move_y";
+            control.interaction_mode = InteractiveMarkerControl::MOVE_AXIS;
+            interactive_marker_->controls.push_back(control);
+
+            server_->insert(*interactive_marker_);
+            server_->setCallback(interactive_marker_->name, boost::bind(&KinBodyMarker::PoseCallback, this, _1));
+            new_marker_ = true;
+        }
+        else if (interactive_marker_)
+        {
+            server_->erase(interactive_marker_->name);
+            interactive_marker_.reset();
+        }
+    }
+
+    void KinBodyMarker::PoseCallback(InteractiveMarkerFeedbackConstPtr const &feedback)
+    {
+        OpenRAVE::KinBodyPtr const kinbody = kinbody_.lock();
+
+        if (feedback->event_type == InteractiveMarkerFeedback::POSE_UPDATE)
+        {
+            OpenRAVE::Transform const pose = toORPose < dReal > (feedback->pose);
+            kinbody->SetTransform(pose);
+        }
+    }
+
+    bool KinBodyMarker::HasGhostManipulator(ManipulatorPtr const manipulator) const
+    {
+        auto const it = manipulator_markers_.find(manipulator.get());
+        return it != manipulator_markers_.end();
+    }
+
+    void KinBodyMarker::GetManipulators(LinkPtr link, std::vector<ManipulatorPtr> *manipulators) const
+    {
+        BOOST_ASSERT(link);
+        BOOST_ASSERT(manipulators);
+
+        // Only robots have manipulators.
+        KinBodyPtr const body = link->GetParent();
+        auto const robot = boost::dynamic_pointer_cast<RobotBase>(body);
+        if (!robot)
+        {
+            return;
+        }
+
+        for (ManipulatorPtr const &manipulator : robot->GetManipulators())
+        {
+            // Check if this link is in the manipulator chain.
+            LinkPtr const base_link = manipulator->GetBase();
+            LinkPtr const tip_link = manipulator->GetEndEffector();
+            std::vector<LinkPtr> chain_links;
+            bool const success = robot->GetChain(base_link->GetIndex(), tip_link->GetIndex(), chain_links);
+            BOOST_ASSERT(success);
+
+            auto const chain_it = std::find(chain_links.begin(), chain_links.end(), link);
+            if (chain_it != chain_links.end())
+            {
+                manipulators->push_back(manipulator);
+                continue;
+            }
+
+            // Check if this link is a child (i.e. part of the end-effector).
+            // TODO: This is necessary because IsChildLink is broken.
+            std::vector<LinkPtr> child_links;
+            manipulator->GetChildLinks(child_links);
+
+            auto const child_it = std::find(child_links.begin(), child_links.end(), link);
+            if (child_it != child_links.end())
+            {
+                manipulators->push_back(manipulator);
+                continue;
+            }
+        }
+    }
+
+}

--- a/src/Markers/KinBodyMarker.h
+++ b/src/Markers/KinBodyMarker.h
@@ -1,0 +1,109 @@
+#ifndef KINBODYMARKER_H_
+#define KINBODYMARKER_H_
+#include <boost/unordered_map.hpp>
+#include <boost/unordered_set.hpp>
+#include <boost/optional.hpp>
+#include <boost/shared_ptr.hpp>
+#include <openrave/openrave.h>
+#include "KinBodyLinkMarker.h"
+#include "KinBodyJointMarker.h"
+#include "ManipulatorMarker.h"
+
+namespace or_interactivemarker
+{
+
+    class KinBodyMarker;
+    typedef boost::shared_ptr<KinBodyMarker> KinBodyMarkerPtr;
+
+    struct LinkMarkerWrapper
+    {
+            typedef interactive_markers::MenuHandler::EntryHandle MenuEntry;
+
+            LinkMarkerWrapper() :
+                    has_menu(false)
+            {
+            }
+
+            KinBodyLinkMarkerPtr link_marker;
+            OpenRAVE::RobotBase::ManipulatorPtr parent_manipulator;
+            bool has_menu;
+            boost::optional<MenuEntry> menu_parent;
+            boost::optional<MenuEntry> menu_joints;
+            boost::optional<MenuEntry> menu_enabled;
+            boost::optional<MenuEntry> menu_visible;
+            boost::optional<MenuEntry> menu_move;
+
+            boost::optional<MenuEntry> menu_groups;
+            boost::unordered_map<std::string, MenuEntry> menu_groups_entries;
+
+            boost::optional<MenuEntry> menu_geometry;
+            boost::optional<MenuEntry> menu_geometry_visual;
+            boost::optional<MenuEntry> menu_geometry_collision;
+            boost::optional<MenuEntry> menu_geometry_both;
+
+            boost::optional<MenuEntry> menu_manipulator;
+            boost::optional<MenuEntry> menu_manipulator_active;
+            boost::optional<MenuEntry> menu_manipulator_joints;
+            boost::optional<MenuEntry> menu_manipulator_ik;
+    };
+
+    struct CustomMenuEntry
+    {
+            std::string name;
+            OpenRAVE::KinBody::LinkWeakPtr link;
+            OpenRAVE::RobotBase::ManipulatorWeakPtr manipulator;
+            boost::function<void()> callback;
+    };
+
+    class KinBodyMarker: public OpenRAVE::UserData
+    {
+        public:
+            KinBodyMarker(boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server, OpenRAVE::KinBodyPtr kinbody);
+            virtual ~KinBodyMarker();
+
+            std::string id() const;
+
+            void AddMenuEntry(std::string const &name, boost::function<void()> const &callback);
+            void AddMenuEntry(OpenRAVE::KinBody::LinkPtr link, std::string const &name, boost::function<void()> const &callback);
+            void AddMenuEntry(OpenRAVE::RobotBase::ManipulatorPtr manipulator, std::string const &name, boost::function<void()> const &callback);
+
+            void EnvironmentSync();
+
+            std::vector<std::string> group_names() const;
+            void SwitchGeometryGroup(std::string const &group);
+
+        private:
+            boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
+            OpenRAVE::KinBodyWeakPtr kinbody_;
+            OpenRAVE::RobotBaseWeakPtr robot_;
+            bool has_pose_controls_;
+            bool has_joint_controls_;
+
+            visualization_msgs::InteractiveMarkerPtr interactive_marker_;
+            bool new_marker_;
+
+            std::vector<CustomMenuEntry> menu_custom_kinbody_;
+            boost::unordered_map<OpenRAVE::KinBody::Link *, std::vector<CustomMenuEntry> > menu_custom_links_;
+            boost::unordered_map<OpenRAVE::RobotBase::Manipulator *, std::vector<CustomMenuEntry> > menu_custom_manipulators_;
+
+            boost::unordered_map<OpenRAVE::KinBody::Link *, LinkMarkerWrapper> link_markers_;
+            boost::unordered_map<OpenRAVE::KinBody::Joint *, KinBodyJointMarkerPtr> joint_markers_;
+            boost::unordered_map<OpenRAVE::RobotBase::Manipulator *, ManipulatorMarkerPtr> manipulator_markers_;
+
+            bool HasGhostManipulator(OpenRAVE::RobotBase::ManipulatorPtr const manipulator) const;
+
+            void CreateMenu(LinkMarkerWrapper &link_wrapper);
+            void UpdateMenu(LinkMarkerWrapper &link_wrapper);
+            void UpdateMenu();
+            void MenuCallback(LinkMarkerWrapper &link_wrapper, visualization_msgs::InteractiveMarkerFeedbackConstPtr const &feedback);
+
+            void CreatePoseControls();
+            void EnablePoseControls(bool enabled);
+            void PoseCallback(visualization_msgs::InteractiveMarkerFeedbackConstPtr const &feedback);
+
+            void GetManipulators(OpenRAVE::KinBody::LinkPtr link, std::vector<OpenRAVE::RobotBase::ManipulatorPtr> *manipulators) const;
+    };
+
+}
+
+#endif

--- a/src/Markers/LinkMarker.cpp
+++ b/src/Markers/LinkMarker.cpp
@@ -1,0 +1,422 @@
+#include <boost/bind.hpp>
+#include <boost/format.hpp>
+#include <boost/make_shared.hpp>
+#include <boost/algorithm/string/join.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/range/adaptor/map.hpp>
+#include <ros/ros.h>
+#include "../or_conversions.h"
+#include "LinkMarker.h"
+
+using boost::adaptors::map_keys;
+using boost::adaptors::transformed;
+using boost::algorithm::join;
+using boost::algorithm::iends_with;
+using boost::format;
+using boost::str;
+using geometry_msgs::Vector3;
+using OpenRAVE::KinBodyPtr;
+using OpenRAVE::RobotBase;
+using OpenRAVE::RobotBasePtr;
+using OpenRAVE::EnvironmentBasePtr;
+using visualization_msgs::Marker;
+using visualization_msgs::MarkerPtr;
+using visualization_msgs::InteractiveMarker;
+using visualization_msgs::InteractiveMarkerPtr;
+using visualization_msgs::InteractiveMarkerControl;
+using visualization_msgs::InteractiveMarkerFeedbackConstPtr;
+using interactive_markers::InteractiveMarkerServer;
+
+typedef OpenRAVE::KinBody::LinkPtr LinkPtr;
+typedef boost::shared_ptr<OpenRAVE::TriMesh> TriMeshPtr;
+typedef OpenRAVE::RobotBase::ManipulatorPtr ManipulatorPtr;
+typedef OpenRAVE::KinBody::Link::GeometryPtr GeometryPtr;
+typedef boost::shared_ptr<InteractiveMarkerServer> InteractiveMarkerServerPtr;
+
+// TODO: Don't hardcode this.
+static std::string const kWorldFrameId = "/map";
+
+namespace or_interactivemarker
+{
+
+    OpenRAVE::Vector const LinkMarker::kCollisionColor(0.0, 0.0, 1.0, 0.5);
+
+    LinkMarker::LinkMarker(boost::shared_ptr<InteractiveMarkerServer> server, LinkPtr link, bool is_ghost) :
+            server_(server), interactive_marker_(boost::make_shared<InteractiveMarker>()), view_visual_(true), view_collision_(false), link_(link), is_ghost_(is_ghost), force_update_(true)
+    {
+        BOOST_ASSERT(server);
+        BOOST_ASSERT(link);
+
+        // TODO: How should we handle this?
+        //manipulator_ = InferManipulator();
+
+        interactive_marker_->header.frame_id = kWorldFrameId;
+        interactive_marker_->name = id();
+        interactive_marker_->description = "";
+        interactive_marker_->pose = toROSPose(link->GetTransform());
+        interactive_marker_->scale = 0.25;
+
+        // Show the visual geometry.
+        interactive_marker_->controls.resize(1);
+        visual_control_ = &interactive_marker_->controls[0];
+        visual_control_->orientation.w = 1;
+        visual_control_->name = str(format("%s.Geometry[visual]") % id());
+        visual_control_->orientation_mode = InteractiveMarkerControl::INHERIT;
+        visual_control_->interaction_mode = InteractiveMarkerControl::BUTTON;
+        visual_control_->always_visible = true;
+    }
+
+    LinkMarker::~LinkMarker()
+    {
+        server_->erase(interactive_marker_->name);
+    }
+
+    std::string LinkMarker::id() const
+    {
+        LinkPtr const link = this->link();
+        KinBodyPtr const body = link->GetParent();
+        EnvironmentBasePtr const env = body->GetEnv();
+        int const environment_id = OpenRAVE::RaveGetEnvironmentId(env);
+
+        std::string suffix;
+        if (is_ghost_)
+        {
+            suffix = ".Ghost";
+        }
+
+        return str(format("Environment[%d].KinBody[%s].Link[%s]%s") % environment_id % body->GetName() % link->GetName() % suffix);
+    }
+
+    LinkPtr LinkMarker::link() const
+    {
+        return link_.lock();
+    }
+
+    void LinkMarker::set_pose(OpenRAVE::Transform const &pose) const
+    {
+        server_->setPose(interactive_marker_->name, toROSPose(pose));
+    }
+
+    void LinkMarker::clear_color()
+    {
+        force_update_ = force_update_ || !!override_color_;
+        override_color_.reset();
+    }
+
+    void LinkMarker::set_color(OpenRAVE::Vector const &color)
+    {
+        force_update_ = force_update_ || !override_color_ || (color[0] != (*override_color_)[0]) || (color[1] != (*override_color_)[1]) || (color[2] != (*override_color_)[2]) || (color[3] != (*override_color_)[3]);
+        override_color_.reset(color);
+    }
+
+    bool LinkMarker::is_view_visual() const
+    {
+        return view_visual_;
+    }
+
+    void LinkMarker::set_view_visual(bool flag)
+    {
+        force_update_ = force_update_ || (flag != view_visual_);
+        view_visual_ = flag;
+    }
+
+    bool LinkMarker::is_view_collision() const
+    {
+        return view_collision_;
+    }
+
+    void LinkMarker::set_view_collision(bool flag)
+    {
+        force_update_ = force_update_ || (flag != view_collision_);
+        view_collision_ = flag;
+    }
+
+    InteractiveMarkerPtr LinkMarker::interactive_marker()
+    {
+        return interactive_marker_;
+    }
+
+    std::vector<std::string> LinkMarker::group_names() const
+    {
+        OpenRAVE::KinBody::LinkInfo const &link_info = link()->GetInfo();
+        auto const range = link_info._mapExtraGeometries | map_keys;
+        return std::vector<std::string>(range.begin(), range.end());
+    }
+
+    void LinkMarker::SwitchGeometryGroup(std::string const &group)
+    {
+        link()->SetGeometriesFromGroup(group);
+        force_update_ = true;
+    }
+
+    bool LinkMarker::EnvironmentSync()
+    {
+        LinkPtr const link = this->link();
+        bool is_changed = force_update_;
+
+        // Check if we need to re-create the marker to propagate changes in the
+        // OpenRAVE environment.
+        for (GeometryPtr const &geometry : link->GetGeometries())
+        {
+            // Check if visibility changed.
+            auto const it1 = geometry_markers_.find(geometry.get());
+            bool const is_missing = it1 == geometry_markers_.end();
+            is_changed = is_changed || is_missing;
+
+            auto const it2 = visibility_map_.find(geometry.get());
+            bool const is_visible = (it2 != visibility_map_.end()) && it2->second;
+            is_changed = is_changed || (is_visible != geometry->IsVisible());
+
+            // TODO  Check if color changed.
+            // TODO: Check if the transform changed.
+            // TODO: Check if the geometry changed.
+
+            if (is_changed)
+            {
+                break;
+            }
+        }
+
+        // Re-create the geometry.
+        if (is_changed)
+        {
+            CreateGeometry();
+            server_->insert(*interactive_marker_);
+        }
+
+        force_update_ = false;
+        return is_changed;
+    }
+
+    void LinkMarker::CreateGeometry()
+    {
+        visual_control_->markers.clear();
+        geometry_markers_.clear();
+
+        LinkPtr const link = this->link();
+
+        for (GeometryPtr const geometry : link->GetGeometries())
+        {
+            // Update this geometry's visibility status.
+            visibility_map_[geometry.get()] = geometry->IsVisible();
+
+            // Note that this inserts an empty vector if the entry does not already
+            // exist. We depend on this for lazy marker creation.
+            std::vector<visualization_msgs::Marker *> &markers = geometry_markers_[geometry.get()];
+
+            if (view_visual_ && geometry->IsVisible())
+            {
+                // Try loading the visual mesh.
+                MarkerPtr visual_marker = CreateVisualGeometry(geometry);
+
+                // Otherwise, fall back on the collision geometry. This mimics the
+                // behavior of qtcoin.
+                if (!visual_marker)
+                {
+                    visual_marker = CreateCollisionGeometry(geometry);
+                }
+
+                if (visual_marker)
+                {
+                    visual_control_->markers.push_back(*visual_marker);
+                    markers.push_back(&visual_control_->markers.back());
+                }
+            }
+
+            if (view_collision_ && link->IsEnabled())
+            {
+                MarkerPtr const collision_marker = CreateCollisionGeometry(geometry);
+
+                // Make the collision geometry partially transparent if we're also
+                // rendering the collision geometry. It's generally true that the
+                // collision geometry is larger than the visual geometry.
+                if (collision_marker && view_visual_)
+                {
+                    collision_marker->color = toROSColor(kCollisionColor);
+                    collision_marker->mesh_use_embedded_materials = false;
+                }
+
+                if (collision_marker)
+                {
+                    visual_control_->markers.push_back(*collision_marker);
+                    markers.push_back(&visual_control_->markers.back());
+                }
+            }
+        }
+    }
+
+    MarkerPtr LinkMarker::CreateVisualGeometry(GeometryPtr geometry)
+    {
+        MarkerPtr marker = boost::make_shared<Marker>();
+        marker->pose = toROSPose(geometry->GetTransform());
+
+        if (override_color_)
+        {
+            marker->color = toROSColor(*override_color_);
+        }
+        else
+        {
+            marker->color = toROSColor(geometry->GetDiffuseColor());
+            marker->color.a = 1.0 - geometry->GetTransparency();
+        }
+
+        // If a render filename is specified, then we should ignore the rest of the
+        // geometry. This is true regardless of the mesh type.
+        std::string render_mesh_path = geometry->GetRenderFilename();
+        if (boost::algorithm::starts_with(render_mesh_path, "__norenderif__"))
+        {
+            render_mesh_path = "";
+        }
+
+        // Pass the path to the mesh to RViz and let RViz load it directly. This is
+        // only possible if RViz supports the mesh format.
+        if (!render_mesh_path.empty() && HasRVizSupport(render_mesh_path))
+        {
+            marker->type = Marker::MESH_RESOURCE;
+            marker->scale = toROSVector(geometry->GetRenderScale());
+            marker->mesh_resource = "file://" + render_mesh_path;
+
+            bool const has_texture = !override_color_ && HasTexture(render_mesh_path);
+            marker->mesh_use_embedded_materials = has_texture;
+
+            // Color must be zero to use the embedded material.
+            if (has_texture)
+            {
+                marker->color.r = 0;
+                marker->color.g = 0;
+                marker->color.b = 0;
+                marker->color.a = 0;
+            }
+            return marker;
+        }
+        // Otherwise, load the mesh with OpenRAVE and serialize the full mesh it
+        // into the marker.
+        else if (!render_mesh_path.empty())
+        {
+            OpenRAVE::EnvironmentBasePtr const env = link()->GetParent()->GetEnv();
+            TriMeshPtr trimesh = boost::make_shared<OpenRAVE::TriMesh>();
+            trimesh = env->ReadTrimeshURI(trimesh, render_mesh_path);
+            if (trimesh)
+            {
+                TriMeshToMarker(*trimesh, marker);
+                marker->scale = toROSVector(geometry->GetInfo()._vCollisionScale);
+
+                static bool already_printed = false;
+                if (!already_printed)
+                {
+                    RAVELOG_WARN("Loaded one or more meshes OpenRAVE because this"
+                            " format is not" " supported by RViz. This may be"
+                            " slow for large files.\n");
+                    already_printed = true;
+                }
+                return marker;
+            }
+            else
+            {
+                RAVELOG_WARN("Loading trimesh '%s' using OpenRAVE failed.", render_mesh_path.c_str());
+            }
+        }
+        return MarkerPtr();
+    }
+
+    MarkerPtr LinkMarker::CreateCollisionGeometry(GeometryPtr geometry)
+    {
+        MarkerPtr marker = boost::make_shared<Marker>();
+        marker->pose = toROSPose(geometry->GetTransform());
+
+        if (override_color_)
+        {
+            marker->color = toROSColor(*override_color_);
+        }
+        else
+        {
+            marker->color = toROSColor(geometry->GetDiffuseColor());
+            marker->color.a = 1.0 - geometry->GetTransparency();
+        }
+
+        switch (geometry->GetType())
+        {
+            case OpenRAVE::GeometryType::GT_None:
+                return MarkerPtr();
+
+            case OpenRAVE::GeometryType::GT_Box:
+                // TODO: This may be off by a factor of two.
+                marker->type = Marker::CUBE;
+                marker->scale = toROSVector(geometry->GetBoxExtents());
+                marker->scale.x *= 2.0;
+                marker->scale.y *= 2.0;
+                marker->scale.z *= 2.0;
+                if (marker->scale.x * marker->scale.y * marker->scale.z == 0.0)
+                {
+                    return MarkerPtr();
+                }
+                break;
+
+            case OpenRAVE::GeometryType::GT_Sphere:
+            {
+                double const sphere_radius = geometry->GetSphereRadius();
+                marker->type = Marker::SPHERE;
+                marker->scale.x = 2.0 * sphere_radius;
+                marker->scale.y = 2.0 * sphere_radius;
+                marker->scale.z = 2.0 * sphere_radius;
+                if (sphere_radius == 0.0)
+                {
+                    return MarkerPtr();
+                }
+                break;
+            }
+
+            case OpenRAVE::GeometryType::GT_Cylinder:
+            {
+                // TODO: This may be rotated and/or off by a factor of two.
+                double const cylinder_radius = geometry->GetCylinderRadius();
+                double const cylinder_height = geometry->GetCylinderHeight();
+                marker->type = Marker::CYLINDER;
+                marker->scale.x = 0.5 * cylinder_radius;
+                marker->scale.y = 0.5 * cylinder_radius;
+                marker->scale.z = cylinder_height;
+                break;
+            }
+
+            case OpenRAVE::GeometryType::GT_TriMesh:
+                TriMeshToMarker(geometry->GetCollisionMesh(), marker);
+                break;
+
+            default:
+                RAVELOG_WARN("Unknown geometry type '%d' for link '%s'.\n", geometry->GetType(), link()->GetName().c_str());
+                return MarkerPtr();
+        }
+        return marker;
+    }
+
+    void LinkMarker::TriMeshToMarker(OpenRAVE::TriMesh const &trimesh, MarkerPtr const &marker)
+    {
+        marker->type = Marker::TRIANGLE_LIST;
+        marker->points.clear();
+
+        BOOST_ASSERT(trimesh.indices.size() % 3 == 0);
+        for (size_t i = 0; i < trimesh.indices.size() / 3; ++i)
+        {
+            int const index1 = trimesh.indices.at(3 * i + 0);
+            int const index2 = trimesh.indices.at(3 * i + 1);
+            int const index3 = trimesh.indices.at(3 * i + 2);
+            OpenRAVE::Vector const &p1 = trimesh.vertices.at(index1);
+            OpenRAVE::Vector const &p2 = trimesh.vertices.at(index2);
+            OpenRAVE::Vector const &p3 = trimesh.vertices.at(index3);
+            marker->points.push_back(toROSPoint(p1));
+            marker->points.push_back(toROSPoint(p2));
+            marker->points.push_back(toROSPoint(p3));
+        }
+    }
+
+    bool LinkMarker::HasTexture(std::string const &uri) const
+    {
+        return iends_with(uri, ".dae");
+    }
+
+    bool LinkMarker::HasRVizSupport(std::string const &uri) const
+    {
+        return iends_with(uri, ".dae") || iends_with(uri, ".stl") || iends_with(uri, ".mesh");
+    }
+
+}

--- a/src/Markers/LinkMarker.h
+++ b/src/Markers/LinkMarker.h
@@ -1,0 +1,78 @@
+#ifndef LINKMARKER_H_
+#define LINKMARKER_H_
+#include <vector>
+#include <boost/optional.hpp>
+#include <boost/unordered_map.hpp>
+#include <boost/shared_ptr.hpp>
+#include <openrave/openrave.h>
+#include <visualization_msgs/InteractiveMarker.h>
+#include <interactive_markers/menu_handler.h>
+#include <interactive_markers/interactive_marker_server.h>
+
+namespace or_interactivemarker
+{
+
+    class LinkMarker;
+    typedef boost::shared_ptr<LinkMarker> LinkMarkerPtr;
+
+    class LinkMarker
+    {
+        public:
+            static OpenRAVE::Vector const kCollisionColor;
+
+            LinkMarker(boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server, OpenRAVE::KinBody::LinkPtr link, bool is_ghost);
+            virtual ~LinkMarker();
+
+            std::string id() const;
+            OpenRAVE::KinBody::LinkPtr link() const;
+            interactive_markers::MenuHandler &menu_handler();
+            visualization_msgs::InteractiveMarkerPtr interactive_marker();
+
+            void set_pose(OpenRAVE::Transform const &pose) const;
+
+            void clear_color();
+            void set_color(OpenRAVE::Vector const &color);
+
+            bool is_view_visual() const;
+            void set_view_visual(bool flag);
+
+            bool is_view_collision() const;
+            void set_view_collision(bool flag);
+
+            std::vector<std::string> group_names() const;
+            void SwitchGeometryGroup(std::string const &group);
+
+            virtual bool EnvironmentSync();
+            void UpdateMenu();
+
+        protected:
+            boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
+            visualization_msgs::InteractiveMarkerPtr interactive_marker_;
+            visualization_msgs::InteractiveMarkerControl *visual_control_;
+
+        private:
+            OpenRAVE::KinBody::LinkWeakPtr link_;
+            OpenRAVE::RobotBase::ManipulatorPtr manipulator_;
+            bool is_ghost_;
+            bool created_;
+            bool force_update_;
+            bool view_visual_;
+            bool view_collision_;
+
+            boost::optional<OpenRAVE::Vector> override_color_;
+
+            boost::unordered_map<OpenRAVE::KinBody::Link::Geometry *, bool> visibility_map_;
+            boost::unordered_map<OpenRAVE::KinBody::Link::Geometry *, std::vector<visualization_msgs::Marker *> > geometry_markers_;
+
+            void CreateGeometry();
+            visualization_msgs::MarkerPtr CreateVisualGeometry(OpenRAVE::KinBody::Link::GeometryPtr geometry);
+            visualization_msgs::MarkerPtr CreateCollisionGeometry(OpenRAVE::KinBody::Link::GeometryPtr geometry);
+
+            bool HasTexture(std::string const &uri) const;
+            bool HasRVizSupport(std::string const &uri) const;
+            void TriMeshToMarker(OpenRAVE::TriMesh const &trimesh, visualization_msgs::MarkerPtr const &marker);
+    };
+
+}
+
+#endif

--- a/src/Markers/ManipulatorMarker.cpp
+++ b/src/Markers/ManipulatorMarker.cpp
@@ -1,0 +1,383 @@
+#include <boost/format.hpp>
+#include <boost/make_shared.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/range/adaptor/map.hpp>
+#include "ManipulatorMarker.h"
+#include "../or_conversions.h"
+
+using boost::format;
+using boost::str;
+using boost::adaptors::map_values;
+using interactive_markers::InteractiveMarkerServer;
+using visualization_msgs::InteractiveMarkerControl;
+using visualization_msgs::InteractiveMarkerFeedback;
+using visualization_msgs::InteractiveMarkerFeedbackConstPtr;
+using OpenRAVE::EnvironmentBasePtr;
+using OpenRAVE::RobotBasePtr;
+using OpenRAVE::KinBody;
+using OpenRAVE::IkSolverBasePtr;
+
+typedef OpenRAVE::RobotBase::RobotStateSaver RobotStateSaver;
+
+typedef boost::shared_ptr<InteractiveMarkerServer> InteractiveMarkerServerPtr;
+typedef OpenRAVE::RobotBase::ManipulatorPtr ManipulatorPtr;
+typedef OpenRAVE::KinBody::Link::GeometryPtr GeometryPtr;
+typedef OpenRAVE::KinBody::LinkPtr LinkPtr;
+typedef OpenRAVE::KinBody::LinkInfo LinkInfo;
+typedef OpenRAVE::KinBody::LinkInfoConstPtr LinkInfoConstPtr;
+typedef OpenRAVE::KinBody::JointPtr JointPtr;
+typedef OpenRAVE::KinBody::JointInfo JointInfo;
+typedef OpenRAVE::KinBody::JointInfoConstPtr JointInfoConstPtr;
+typedef OpenRAVE::RobotBase::ManipulatorInfo ManipulatorInfo;
+typedef OpenRAVE::RobotBase::ManipulatorInfoConstPtr ManipulatorInfoConstPtr;
+typedef OpenRAVE::RobotBase::AttachedSensorInfo AttachedSensorInfo;
+typedef OpenRAVE::RobotBase::AttachedSensorInfoConstPtr AttachedSensorInfoConstPtr;
+
+// TODO: Don't hardcode this.
+static std::string const kWorldFrameId = "/map";
+static std::string const kGhostKey = "interactive_marker::ghost";
+
+namespace or_interactivemarker
+{
+
+    OpenRAVE::Vector const ManipulatorMarker::kValidColor(0, 1, 0, 0.4);
+    OpenRAVE::Vector const ManipulatorMarker::kInvalidColor(1, 0, 0, 0.4);
+
+    ManipulatorMarker::ManipulatorMarker(InteractiveMarkerServerPtr server, ManipulatorPtr manipulator) :
+            server_(server), manipulator_(manipulator), changed_pose_(true), has_ik_(true), current_pose_(manipulator->GetEndEffectorTransform())
+    {
+        BOOST_ASSERT(server_);
+        BOOST_ASSERT(manipulator);
+
+        // Create the ghost manipulator.
+        CreateGeometry();
+
+        // Create a 6-DOF pose control.
+        ik_marker_.header.frame_id = kWorldFrameId;
+        ik_marker_.name = id();
+        ik_marker_.description = manipulator_->GetName();
+        ik_marker_.pose = toROSPose(manipulator->GetEndEffectorTransform());
+        ik_marker_.scale = 0.25;
+
+        {
+            InteractiveMarkerControl control;
+
+            control.orientation.w = 1;
+            control.orientation.x = 1;
+            control.orientation.y = 0;
+            control.orientation.z = 0;
+            control.name = "rotate_x";
+            control.interaction_mode = InteractiveMarkerControl::ROTATE_AXIS;
+            ik_marker_.controls.push_back(control);
+            control.name = "move_x";
+            control.interaction_mode = InteractiveMarkerControl::MOVE_AXIS;
+            ik_marker_.controls.push_back(control);
+
+            control.orientation.w = 1;
+            control.orientation.x = 0;
+            control.orientation.y = 1;
+            control.orientation.z = 0;
+            control.name = "rotate_y";
+            control.interaction_mode = InteractiveMarkerControl::ROTATE_AXIS;
+            ik_marker_.controls.push_back(control);
+            control.name = "move_y";
+            control.interaction_mode = InteractiveMarkerControl::MOVE_AXIS;
+            ik_marker_.controls.push_back(control);
+
+            control.orientation.w = 1;
+            control.orientation.x = 0;
+            control.orientation.y = 0;
+            control.orientation.z = 1;
+            control.name = "rotate_z";
+            control.interaction_mode = InteractiveMarkerControl::ROTATE_AXIS;
+            ik_marker_.controls.push_back(control);
+            control.name = "move_z";
+            control.interaction_mode = InteractiveMarkerControl::MOVE_AXIS;
+            ik_marker_.controls.push_back(control);
+        }
+
+        server_->insert(ik_marker_);
+        server_->setCallback(ik_marker_.name, boost::bind(&ManipulatorMarker::IkFeedback, this, _1));
+
+        CreateMenu();
+    }
+
+    ManipulatorMarker::~ManipulatorMarker()
+    {
+        server_->erase(ik_marker_.name);
+    }
+
+    std::string ManipulatorMarker::id() const
+    {
+        OpenRAVE::RobotBasePtr const robot = manipulator_->GetRobot();
+        OpenRAVE::EnvironmentBasePtr const env = robot->GetEnv();
+        int const environment_id = OpenRAVE::RaveGetEnvironmentId(env);
+
+        return str(format("Environment[%d].KinBody[%s].Manipulator[%s]") % environment_id % robot->GetName() % manipulator_->GetName());
+    }
+
+    bool ManipulatorMarker::EnvironmentSync()
+    {
+        ManipulatorPtr const manipulator = manipulator_;
+        RobotBasePtr const robot = manipulator->GetRobot();
+        IkSolverBasePtr const ik_solver = manipulator->GetIkSolver();
+        RobotStateSaver const saver(robot, KinBody::Save_LinkTransformation);
+
+        // Figure out what the free joints are.
+        size_t const num_free = ik_solver->GetNumFreeParameters();
+        std::vector<JointPtr> free_joints;
+        InferFreeJoints(&free_joints);
+        BOOST_ASSERT(free_joints.size() == num_free);
+
+        std::vector<int> free_dof_indices;
+        for (JointPtr const &free_joint : free_joints)
+        {
+            free_dof_indices.push_back(free_joint->GetJointIndex());
+        }
+
+        if (ik_solver)
+        {
+            RobotStateSaver const free_saver(robot, KinBody::Save_LinkTransformation);
+
+            // Default to the current configuration of the robot.
+            if (current_free_.size() != num_free)
+            {
+                robot->GetDOFValues(current_free_, free_dof_indices);
+            }
+
+            // Extract free parameters from the joint controls.
+            bool changed_free = false;
+            for (size_t ifree = 0; ifree < num_free; ++ifree)
+            {
+                JointPtr const &joint = free_joints[ifree];
+                auto const it = free_joint_markers_.find(joint.get());
+                if (it == free_joint_markers_.end())
+                {
+                    continue;
+                }
+
+                // Invalidate the IK solution if we change the free joint.
+                JointMarkerPtr &joint_marker = it->second;
+                if (joint_marker->angle() != current_free_[ifree])
+                {
+                    current_free_[ifree] = joint_marker->angle();
+                    changed_free = true;
+                }
+            }
+
+            // Set and clamp these joint values to be within limits.
+            robot->SetDOFValues(current_free_, KinBody::CLA_CheckLimitsSilent, free_dof_indices);
+            robot->GetDOFValues(current_free_, free_dof_indices);
+
+            // Update our IK solution.
+            if (changed_pose_ || changed_free)
+            {
+                std::vector<OpenRAVE::dReal> new_ik;
+                OpenRAVE::IkParameterization ik_param;
+                ik_param.SetTransform6D(current_pose_);
+
+                std::vector<std::vector<OpenRAVE::dReal> > ik_solutions;
+                has_ik_ = manipulator_->FindIKSolution(ik_param, new_ik, 0);
+                if (has_ik_)
+                {
+                    current_ik_ = new_ik;
+                }
+            }
+        }
+        changed_pose_ = false;
+
+        // Update the pose of the ghost manipulator.
+        auto const dof_indices = manipulator->GetArmIndices();
+        robot->SetDOFValues(current_ik_, 1, dof_indices);
+
+        bool is_changed = false;
+        for (LinkMarkerPtr const &link_marker : link_markers_ | map_values)
+        {
+            bool const is_link_changed = link_marker->EnvironmentSync();
+            if (!is_link_changed)
+            {
+                OpenRAVE::Transform const link_pose = link_marker->link()->GetTransform();
+                link_marker->set_pose(link_pose);
+            }
+            else
+            {
+                UpdateMenu(link_marker);
+            }
+
+            // Set the color to indicate whether we have a valid IK solution.
+            if (has_ik_)
+            {
+                link_marker->set_color(kValidColor);
+            }
+            else
+            {
+                link_marker->set_color(kInvalidColor);
+            }
+
+            is_changed = is_changed || is_link_changed;
+        }
+
+        if (ik_solver)
+        {
+            for (JointPtr const &joint : free_joints)
+            {
+                if (!joint)
+                {
+                    continue;
+                }
+
+                // Lazily create the marker if it is missing.
+                JointMarkerPtr &joint_marker = free_joint_markers_[joint.get()];
+                if (!joint_marker)
+                {
+                    joint_marker = boost::make_shared<JointMarker>(server_, joint);
+                }
+
+                // Update the pose of the control to match the ghost arm.
+                OpenRAVE::Transform const joint_pose = JointMarker::GetJointPose(joint);
+                joint_marker->set_pose(joint_pose);
+
+                bool const is_joint_changed = joint_marker->EnvironmentSync();
+                is_changed = is_changed || is_joint_changed;
+            }
+        }
+        return is_changed;
+    }
+
+    void ManipulatorMarker::CreateGeometry()
+    {
+        link_markers_.clear();
+
+        ManipulatorPtr const manipulator = manipulator_;
+        RobotBasePtr const robot = manipulator->GetRobot();
+
+        // Get links in the manipulator chain.
+        std::vector<LinkPtr> chain_links;
+        LinkPtr const base_link = manipulator->GetBase();
+        LinkPtr const tip_link = manipulator->GetEndEffector();
+        bool const success = robot->GetChain(base_link->GetIndex(), tip_link->GetIndex(), chain_links);
+        BOOST_ASSERT(success);
+
+        // Get end-effector links.
+        std::vector<LinkPtr> child_links;
+        manipulator->GetChildLinks(child_links);
+
+        // Remove duplicates in case the end-effector link is double-counted.
+        std::set<LinkPtr> links;
+        links.insert(chain_links.begin(), chain_links.end());
+        links.insert(child_links.begin(), child_links.end());
+
+        // Render each link using a LinkMarker.
+        for (LinkPtr const &link : links)
+        {
+            link_markers_[link.get()] = boost::make_shared<LinkMarker>(server_, link, true);
+        }
+    }
+
+    void ManipulatorMarker::CreateMenu()
+    {
+        auto const cb = boost::bind(&ManipulatorMarker::MenuCallback, this, _1);
+
+        menu_set_ = menu_handler_.insert("Set DOF Values", cb);
+        menu_reset_ = menu_handler_.insert("Restore DOF Values", cb);
+    }
+
+    void ManipulatorMarker::UpdateMenu()
+    {
+        for (LinkMarkerPtr const &link_marker : link_markers_ | map_values)
+        {
+            UpdateMenu(link_marker);
+        }
+    }
+
+    void ManipulatorMarker::UpdateMenu(LinkMarkerPtr link_marker)
+    {
+        menu_handler_.apply(*server_, link_marker->interactive_marker()->name);
+    }
+
+    void ManipulatorMarker::MenuCallback(InteractiveMarkerFeedbackConstPtr const &feedback)
+    {
+        ManipulatorPtr const manipulator = manipulator_;
+        RobotBasePtr const robot = manipulator->GetRobot();
+        std::vector<int> const &arm_indices = manipulator->GetArmIndices();
+
+        if (feedback->menu_entry_id == menu_set_)
+        {
+            robot->SetDOFValues(current_ik_, KinBody::CLA_CheckLimits, arm_indices);
+            RAVELOG_DEBUG("Set manipulator '%s' to IK solution.\n", manipulator->GetName().c_str());
+        }
+        else if (feedback->menu_entry_id == menu_reset_)
+        {
+            robot->GetDOFValues(current_ik_, arm_indices);
+            current_pose_ = manipulator_->GetEndEffectorTransform();
+            current_free_.clear();
+            RAVELOG_DEBUG("Snapped to current configuration of manipulator '%s'.\n", manipulator->GetName().c_str());
+        }
+    }
+
+    void ManipulatorMarker::IkFeedback(InteractiveMarkerFeedbackConstPtr const &feedback)
+    {
+        if (feedback->event_type == InteractiveMarkerFeedback::POSE_UPDATE)
+        {
+            current_pose_ = toORPose<OpenRAVE::dReal>(feedback->pose);
+            changed_pose_ = true;
+        }
+    }
+
+    void ManipulatorMarker::InferFreeJoints(std::vector<JointPtr> *free_joints) const
+    {
+        static OpenRAVE::dReal const kEpsilon = 1e-3;
+
+        ManipulatorPtr const manipulator = manipulator_;
+        RobotBasePtr const robot = manipulator->GetRobot();
+        IkSolverBasePtr const ik_solver = manipulator->GetIkSolver();
+
+        std::vector<OpenRAVE::dReal> lower_limits, upper_limits;
+        robot->GetDOFLimits(lower_limits, upper_limits);
+
+        // We'll only accept a joint if it changes the value by at least kEpsilon.
+        size_t const num_free = ik_solver->GetNumFreeParameters();
+        std::vector<OpenRAVE::dReal> best_ratio(num_free, kEpsilon);
+        std::vector<JointPtr> &best_joints = *free_joints;
+        best_joints.assign(num_free, JointPtr());
+
+        // Calculate the sensitivity of the free parameters to each joint.
+        std::vector<int> const &arm_indices = manipulator->GetArmIndices();
+        std::vector<OpenRAVE::dReal> free_motion;
+        for (int const dof_index : arm_indices)
+        {
+            RobotStateSaver const saver(robot, KinBody::Save_LinkTransformation);
+            std::vector<OpenRAVE::dReal> dof_values;
+            robot->GetDOFValues(dof_values);
+
+            // Move the joint to its limits.
+            std::vector<OpenRAVE::dReal> lower_free;
+            dof_values[dof_index] = lower_limits[dof_index];
+            robot->SetDOFValues(dof_values);
+            ik_solver->GetFreeParameters(lower_free);
+            BOOST_ASSERT(lower_free.size() == num_free);
+
+            std::vector<OpenRAVE::dReal> upper_free;
+            dof_values[dof_index] = upper_limits[dof_index];
+            robot->SetDOFValues(dof_values);
+            ik_solver->GetFreeParameters(upper_free);
+            BOOST_ASSERT(upper_free.size() == num_free);
+
+            // Calculate the relative change in free parameters.
+            for (size_t ifree = 0; ifree < num_free; ++ifree)
+            {
+                double const delta_param = upper_free[ifree] - lower_free[ifree];
+                double const delta_value = upper_limits[ifree] - lower_limits[ifree];
+                BOOST_ASSERT(delta_value > 0);
+                double const ratio = std::fabs(delta_param / delta_value);
+
+                if (ratio > best_ratio[ifree])
+                {
+                    best_ratio[ifree] = ratio;
+                    best_joints[ifree] = robot->GetJointFromDOFIndex(dof_index);
+                }
+            }
+        }
+    }
+
+}

--- a/src/Markers/ManipulatorMarker.h
+++ b/src/Markers/ManipulatorMarker.h
@@ -1,0 +1,59 @@
+#ifndef MANIPULATORMARKER_H_
+#define MANIPULATORMARKER_H_
+#include <boost/unordered_map.hpp>
+#include <openrave/openrave.h>
+#include <interactive_markers/interactive_marker_server.h>
+#include "LinkMarker.h"
+#include "JointMarker.h"
+
+namespace or_interactivemarker
+{
+
+    class ManipulatorMarker;
+    typedef boost::shared_ptr<ManipulatorMarker> ManipulatorMarkerPtr;
+
+    class ManipulatorMarker
+    {
+        public:
+            static OpenRAVE::Vector const kValidColor;
+            static OpenRAVE::Vector const kInvalidColor;
+
+            ManipulatorMarker(boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server, OpenRAVE::RobotBase::ManipulatorPtr manipulator);
+            virtual ~ManipulatorMarker();
+
+            std::string id() const;
+            bool EnvironmentSync();
+            void UpdateMenu();
+
+        private:
+            boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
+            OpenRAVE::RobotBase::ManipulatorPtr manipulator_;
+
+            visualization_msgs::InteractiveMarker ik_marker_;
+            visualization_msgs::InteractiveMarkerControl *ik_control_;
+            boost::unordered_map<OpenRAVE::KinBody::Link *, LinkMarkerPtr> link_markers_;
+            boost::unordered_map<OpenRAVE::KinBody::Joint *, JointMarkerPtr> free_joint_markers_;
+
+            bool changed_pose_;
+            bool has_ik_;
+            OpenRAVE::Transform current_pose_;
+            std::vector<OpenRAVE::dReal> current_ik_;
+            std::vector<OpenRAVE::dReal> current_free_;
+
+            interactive_markers::MenuHandler menu_handler_;
+            interactive_markers::MenuHandler::EntryHandle menu_set_;
+            interactive_markers::MenuHandler::EntryHandle menu_reset_;
+
+            void CreateGeometry();
+
+            void CreateMenu();
+            void UpdateMenu(LinkMarkerPtr link_marker);
+            void MenuCallback(visualization_msgs::InteractiveMarkerFeedbackConstPtr const &feedback);
+
+            void IkFeedback(visualization_msgs::InteractiveMarkerFeedbackConstPtr const &feedback);
+            void InferFreeJoints(std::vector<OpenRAVE::KinBody::JointPtr> *free_joints) const;
+    };
+
+}
+
+#endif

--- a/src/OpenRaveRviz.cpp
+++ b/src/OpenRaveRviz.cpp
@@ -29,10 +29,94 @@
 #include <rviz/default_plugin/interactive_marker_display.h>
 #include <rviz/ogre_helpers/arrow.h>
 #include <boost/thread/locks.hpp>
-
+#include <boost/signals2.hpp>
+#include <boost/algorithm/string.hpp>
+#include <interactive_markers/interactive_marker_server.h>
+#include "or_conversions.h"
+static double const kRefreshRate = 30;
+static double const kWidthScaleFactor = 100;
 using namespace OpenRAVE;
 using namespace rviz;
+using namespace or_interactivemarker;
 
+namespace detail
+{
+
+    class ScopedConnection: public OpenRAVE::UserData
+    {
+        public:
+            ScopedConnection(boost::signals2::connection const &connection) :
+                    scoped_connection_(connection)
+            {
+            }
+
+            virtual ~ScopedConnection()
+            {
+            }
+
+        private:
+            boost::signals2::scoped_connection scoped_connection_;
+    };
+
+    static std::string GetRemainingContent(std::istream &stream, bool trim = false)
+    {
+
+        std::istreambuf_iterator<char> eos;
+        std::string str(std::istreambuf_iterator<char>(stream), eos);
+        if (trim)
+        {
+            boost::algorithm::trim(str);
+        }
+        return str;
+    }
+
+    class InteractiveMarkerGraphHandle: public OpenRAVE::GraphHandle
+    {
+        public:
+            InteractiveMarkerGraphHandle(boost::shared_ptr<interactive_markers::InteractiveMarkerServer> const &interactive_marker_server, visualization_msgs::InteractiveMarkerPtr const &interactive_marker) :
+                    server_(interactive_marker_server), interactive_marker_(interactive_marker), show_(true)
+            {
+                BOOST_ASSERT(interactive_marker_server);
+                BOOST_ASSERT(interactive_marker);
+
+                server_->insert(*interactive_marker_);
+            }
+
+            virtual ~InteractiveMarkerGraphHandle()
+            {
+                server_->erase(interactive_marker_->name);
+            }
+
+            virtual void SetTransform(OpenRAVE::RaveTransform<float> const &t)
+            {
+                // TODO: This could SEGFAULT if it is called too quickly after the
+                // marker is created.
+                if (show_)
+                {
+                    server_->setPose(interactive_marker_->name, or_interactivemarker::toROSPose<>(t));
+                }
+            }
+
+            virtual void SetShow(bool show)
+            {
+                if (show && !show_)
+                {
+                    server_->insert(*interactive_marker_);
+                }
+                else if (!show && show_)
+                {
+                    server_->erase(interactive_marker_->name);
+                }
+                show_ = show;
+            }
+
+        private:
+            boost::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
+            visualization_msgs::InteractiveMarkerPtr interactive_marker_;
+            bool show_;
+    };
+
+}
 
 namespace or_rviz
 {
@@ -44,8 +128,12 @@ namespace or_rviz
             m_mainRenderPanel(NULL),
             m_envDisplay(NULL),
             m_autoSync(false),
-            m_name("or_rviz")
+            m_name("or_rviz"),
+            server_(boost::make_shared<interactive_markers::InteractiveMarkerServer>("openrave")),
+            running_(false),
+            do_sync_(true)
     {
+        BOOST_ASSERT(env);
 
         SetCurrentViewEnv(env);
         setWindowTitle("Openrave Rviz Viewer[*]");
@@ -105,36 +193,14 @@ namespace or_rviz
         m_offscreenRenderer->setVisible(false);
         //m_offscreenRenderer->setHidden(true);
 
-        RegisterCommand("register", boost::bind(&OpenRaveRviz::RegisterMenuCallback, this, _1, _2), "register [objectName] [menuItemName] [pointer] Registers a python object with the given pointer (as a string) to the menu of a kinbody.");
-        RegisterCommand("unregister", boost::bind(&OpenRaveRviz::UnRegisterMenuCallback, this, _1, _2), "register [objectName] [menuItemName] Unregisters the menu command given.");
-
+        //RegisterCommand("register", boost::bind(&OpenRaveRviz::RegisterMenuCallback, this, _1, _2), "register [objectName] [menuItemName] [pointer] Registers a python object with the given pointer (as a string) to the menu of a kinbody.");
+        //RegisterCommand("unregister", boost::bind(&OpenRaveRviz::UnRegisterMenuCallback, this, _1, _2), "register [objectName] [menuItemName] Unregisters the menu command given.");
+        RegisterCommand("AddMenuEntry", boost::bind(&OpenRaveRviz::AddMenuEntryCommand, this, _1, _2), "Attach a custom menu entry to an object.");
+        RegisterCommand("GetMenuSelection", boost::bind(&OpenRaveRviz::GetMenuSelectionCommand, this, _1, _2), "Get the name of the last menu selection.");
         m_offscreenCamera = m_rvizManager->getSceneManager()->createCamera("OfscreenCamera");
-    }
 
-    bool OpenRaveRviz::RegisterMenuCallback(std::ostream& sout, std::istream& sinput)
-    {
-        std::string objectName;
-        sinput >> objectName;
-
-        std::string menuName;
-        sinput >> menuName;
-
-        std::string pyFunctionPtr;
-        sinput >> pyFunctionPtr;
-
-        return m_envDisplay->RegisterMenuCallback(objectName, menuName, pyFunctionPtr);
-    }
-
-    bool OpenRaveRviz::UnRegisterMenuCallback(std::ostream& sout, std::istream& sinput)
-    {
-
-        std::string objectName;
-        sinput >> objectName;
-
-        std::string menuName;
-        sinput >> menuName;
-
-        return m_envDisplay->UnRegisterMenuCallback(objectName, menuName);
+        rviz::InteractiveMarkerDisplay* markerDisplay =  dynamic_cast< rviz::InteractiveMarkerDisplay*>(m_rvizManager->createDisplay("rviz/InteractiveMarkers", "OpenRAVE Markers", true));
+        markerDisplay->setTopic("/openrave/update", "");
     }
 
 
@@ -170,13 +236,85 @@ namespace or_rviz
         {
             show();
         }
-
+        running_ = true;
         return qApp->exec();
     }
 
     void OpenRaveRviz::quitmainloop()
     {
+        running_ = false;
         qApp->quit();
+    }
+
+    bool OpenRaveRviz::AddMenuEntryCommand(std::ostream &out, std::istream &in)
+    {
+        std::string type, kinbody_name;
+        in >> type >> kinbody_name;
+
+        // Get the KinBodyMarker associated with the target object.
+        OpenRAVE::KinBodyPtr const kinbody = GetCurrentViewEnv()->GetKinBody(kinbody_name);
+        if (!kinbody)
+        {
+            throw OpenRAVE::openrave_exception(boost::str(boost::format("There is no KinBody named '%s' in the environment.") % kinbody_name), OpenRAVE::ORE_Failed);
+        }
+
+        OpenRAVE::UserDataPtr const marker_raw = kinbody->GetUserData("interactive_marker");
+        auto const marker = boost::dynamic_pointer_cast<KinBodyMarker>(marker_raw);
+        if (!marker)
+        {
+            throw OpenRAVE::openrave_exception(boost::str(boost::format("KinBody '%s' does not have an associated marker.") % kinbody_name), OpenRAVE::ORE_InvalidState);
+        }
+
+        if (type == "kinbody")
+        {
+            std::string const name = detail::GetRemainingContent(in, true);
+            auto const callback = boost::bind(&OpenRaveRviz::KinBodyMenuCallback, this, kinbody, name);
+            marker->AddMenuEntry(name, callback);
+        }
+        else if (type == "link")
+        {
+            std::string link_name;
+            in >> link_name;
+
+            OpenRAVE::KinBody::LinkPtr const link = kinbody->GetLink(link_name);
+            if (!link)
+            {
+                throw OpenRAVE::openrave_exception(boost::str(boost::format("KinBody '%s' has no link '%s'.") % kinbody_name % link_name), OpenRAVE::ORE_Failed);
+            }
+
+            std::string const name = detail::GetRemainingContent(in, true);
+            auto const callback = boost::bind(&OpenRaveRviz::LinkMenuCallback, this, link, name);
+            marker->AddMenuEntry(link, name, callback);
+        }
+        else if (type == "manipulator" || type == "ghost_manipulator")
+        {
+            std::string manipulator_name;
+            in >> manipulator_name;
+
+            if (!kinbody->IsRobot())
+            {
+                throw OpenRAVE::openrave_exception(boost::str(boost::format("KinBody '%s' is not a robot and does not support"
+                        " manipulator menus.") % kinbody_name), OpenRAVE::ORE_Failed);
+            }
+
+            auto const robot = boost::dynamic_pointer_cast<OpenRAVE::RobotBase>(kinbody);
+            OpenRAVE::RobotBase::ManipulatorPtr const manipulator = robot->GetManipulator(manipulator_name);
+            if (!manipulator)
+            {
+                throw OpenRAVE::openrave_exception(boost::str(boost::format("Robot '%s' has no manipulator '%s'.") % kinbody_name % manipulator_name), OpenRAVE::ORE_Failed);
+            }
+
+            std::string const name = detail::GetRemainingContent(in, true);
+            auto const callback = boost::bind(&OpenRaveRviz::ManipulatorMenuCallback, this, manipulator, name);
+            marker->AddMenuEntry(manipulator, name, callback);
+        }
+        return true;
+    }
+
+    bool OpenRaveRviz::GetMenuSelectionCommand(std::ostream &out, std::istream &in)
+    {
+        out << menu_queue_.rdbuf();
+        return true;
     }
 
 
@@ -269,8 +407,6 @@ namespace or_rviz
 
     void OpenRaveRviz::Reset()
     {
-        //TODO: FIXME
-        //m_rvizManager->removeDisplay(m_envDisplay->getName());
         delete m_envDisplay;
         m_envDisplay = NULL;
     }
@@ -278,8 +414,6 @@ namespace or_rviz
 
     void OpenRaveRviz::SetBkgndColor(const OpenRAVE::RaveVector<float> &color)
     {
-        // TODO: FIXME
-        //m_rvizManager->setBackgroundColor(rviz::Color(color.x, color.y, color.z));
         m_rvizManager->getRenderPanel()->setBackgroundColor(Ogre::ColourValue(color.x, color.y, color.z));
     }
 
@@ -314,6 +448,7 @@ namespace or_rviz
     // controls whether the viewer synchronizes with the newest environment automatically
     void OpenRaveRviz::SetEnvironmentSync(bool update)
     {
+        do_sync_ = update;
         SetAutoSync(update);
     }
 
@@ -356,6 +491,11 @@ namespace or_rviz
             OpenRAVE::EnvironmentMutex::scoped_lock environment_lock(pbody->GetEnv()->GetMutex());
             m_envDisplay->RemoveKinBody(pbody->GetName());
         }
+
+        if (pbody)
+        {
+            pbody->RemoveUserData("interactive_marker");
+        }
     }
 
     void OpenRaveRviz::UpdateDisplay()
@@ -368,29 +508,6 @@ namespace or_rviz
         if (!m_envDisplay)
         {
             m_envDisplay = dynamic_cast<EnvironmentDisplay*>(m_rvizManager->createDisplay("or_rviz/Environment", "OpenRAVE", true));
-            //rviz::InteractiveMarkerDisplay* markerDisplay = dynamic_cast<InteractiveMarkerDisplay*>(m_rvizManager->createDisplay("rviz/InteractiveMarker", "OpenRAVEInteraction", true));
-           //setMarkerUpdateTopic("openrave_markers/update");
-            /*// TODO: FIXME
-            rviz::DisplayWrapper* wrapper = m_rvizManager->getDisplayWrapper("OpenRAVE");
-
-            if (!wrapper)
-            {
-                wrapper = m_rvizManager->createDisplay("or_rviz/Environment", "OpenRAVE", true);
-            }
-
-            m_envDisplay = dynamic_cast<EnvironmentDisplay*>(wrapper->getDisplay());
-
-
-
-            rviz::DisplayWrapper* interactiveWrapper = m_rvizManager->getDisplayWrapper("OpenRAVEInteraction");
-
-            if (!interactiveWrapper)
-            {
-                interactiveWrapper = m_rvizManager->createDisplay("rviz/InteractiveMarker", "OpenRAVEInteraction", true);
-            }
-            rviz::InteractiveMarkerDisplay* markerDisplay = dynamic_cast<InteractiveMarkerDisplay*>(interactiveWrapper->getDisplay());
-            markerDisplay->setMarkerUpdateTopic("openrave_markers/update");
-            */
         }
 
         if (m_envDisplay)
@@ -529,8 +646,6 @@ namespace or_rviz
                 continue;
             }
 
-          // RAVELOG_DEBUG("Creating texture %s, size: %d %d\n", req->name.c_str(), req->width, req->height);
-
             Ogre::TextureManager::getSingleton().unload(req->name);
             Ogre::TextureManager::getSingleton().remove(req->name);
 
@@ -548,8 +663,6 @@ namespace or_rviz
            Ogre::RenderTexture* renderTexture = req->texture->getBuffer()->getRenderTarget();
            renderTexture->addViewport(m_offscreenCamera);
            renderTexture->copyContentsToMemory(*req->pixelBox, Ogre::RenderTarget::FB_AUTO);
-
-
 
            req->valid = true;
 
@@ -586,23 +699,38 @@ namespace or_rviz
 
         HandleRenderTargetRequests();
         setWindowTitle("Openrave Rviz Viewer[*]");
+        if (GetCurrentViewEnv()->GetMutex().try_lock())
         {
-            if(GetCurrentViewEnv()->GetMutex().try_lock())
+            //UpdateDisplay();
+            HandleMenus();
+            GetCurrentViewEnv()->GetMutex().unlock();
+
+            std::vector<KinBodyPtr> bodies;
+            GetCurrentViewEnv()->GetBodies(bodies);
+
+            for (KinBodyPtr body : bodies)
             {
-                //OpenRAVE::EnvironmentMutex::scoped_lock environment_lock(GetCurrentViewEnv()->GetMutex());
-                UpdateDisplay();
-                HandleMenus();
-                GetCurrentViewEnv()->GetMutex().unlock();
+                OpenRAVE::UserDataPtr const raw = body->GetUserData("interactive_marker");
+                auto body_marker = boost::dynamic_pointer_cast<KinBodyMarker>(raw);
+                BOOST_ASSERT(!raw || body_marker);
+
+                // Create the new geometry if neccessary.
+                if (!raw)
+                {
+                    RAVELOG_INFO("Creating KinBodyMarker for '%s'.\n", body->GetName().c_str());
+                    body_marker = boost::make_shared<KinBodyMarker>(server_, body);
+                    body->SetUserData("interactive_marker", body_marker);
+                }
+
+                body_marker->EnvironmentSync();
             }
         }
-
         for(std::map<size_t, ViewerThreadCallbackFn>::iterator it = m_syncCallbacks.begin(); it != m_syncCallbacks.end(); it++)
         {
             it->second();
         }
 
-        //ros::spinOnce();
-
+        server_->applyChanges();
     }
 
     // Viewer size and position can be set outside in the
@@ -637,6 +765,7 @@ namespace or_rviz
     // Set the camera transformation.
     void OpenRaveRviz::SetCamera (const OpenRAVE::RaveTransform<float> &trans, float focalDistance)
     {
+        getManager()->getViewManager()->
         SetCamera(getManager()->getRenderPanel()->getCamera(), trans, focalDistance);
     }
 
@@ -711,10 +840,218 @@ namespace or_rviz
         return true;
     }
 
+    GraphHandlePtr OpenRaveRviz::plot3_marker(float const *points, int num_points, int stride, float point_size, OpenRAVE::RaveVector<float> const &color, int draw_style)
+    {
+        visualization_msgs::InteractiveMarkerPtr interactive_marker = CreateMarker();
+        visualization_msgs::Marker &marker = interactive_marker->controls.front().markers.front();
+        marker.color = toROSColor<>(color);
+
+        if (draw_style == 0)
+        {
+            marker.type = visualization_msgs::Marker::POINTS;
+            marker.scale.x = point_size;
+            marker.scale.y = point_size;
+        }
+        else if (draw_style == 1)
+        {
+            marker.type = visualization_msgs::Marker::SPHERE_LIST;
+            marker.scale.x = point_size;
+            marker.scale.y = point_size;
+            marker.scale.z = point_size;
+        }
+        else
+        {
+            throw OpenRAVE::openrave_exception(boost::str(boost::format("Unsupported drawstyle %d; expected 0 or 1.") % draw_style), OpenRAVE::ORE_InvalidArguments);
+        }
+
+        ConvertPoints(points, num_points, stride, &marker.points);
+
+        return boost::make_shared<detail::InteractiveMarkerGraphHandle>(server_, interactive_marker);
+    }
+
+    OpenRAVE::GraphHandlePtr OpenRaveRviz::plot3_marker(float const *points, int num_points, int stride, float point_size, float const *colors, int draw_style, bool has_alpha)
+    {
+        visualization_msgs::InteractiveMarkerPtr interactive_marker = CreateMarker();
+        visualization_msgs::Marker &marker = interactive_marker->controls.front().markers.front();
+
+        if (draw_style == 0)
+        {
+            marker.type = visualization_msgs::Marker::POINTS;
+            marker.scale.x = point_size;
+            marker.scale.y = point_size;
+        }
+        else if (draw_style == 1)
+        {
+            // TODO: Does this support individual colors?
+            marker.type = visualization_msgs::Marker::SPHERE_LIST;
+            marker.scale.x = point_size;
+            marker.scale.y = point_size;
+            marker.scale.z = point_size;
+        }
+        else
+        {
+            throw OpenRAVE::openrave_exception(boost::str(boost::format("Unsupported drawstyle %d; expected 0 or 1.") % draw_style), OpenRAVE::ORE_InvalidArguments);
+        }
+
+        ConvertPoints(points, num_points, stride, &marker.points);
+        ConvertColors(colors, num_points, has_alpha, &marker.colors);
+
+        return boost::make_shared<detail::InteractiveMarkerGraphHandle>(server_, interactive_marker);
+    }
+
+    GraphHandlePtr OpenRaveRviz::drawarrow_marker (const OpenRAVE::RaveVector< float > &p1, const OpenRAVE::RaveVector< float > &p2, float fwidth, const OpenRAVE::RaveVector< float > &color)
+    {
+        visualization_msgs::InteractiveMarkerPtr interactive_marker = CreateMarker();
+        visualization_msgs::Marker &marker = interactive_marker->controls.front().markers.front();
+        marker.type = visualization_msgs::Marker::ARROW;
+        marker.color = toROSColor<>(color);
+        marker.scale.x = fwidth * 1.0f;
+        marker.scale.y = fwidth * 1.5f;
+        marker.scale.z = fwidth * 2.0f;
+        marker.points.push_back(toROSPoint(p1));
+        marker.points.push_back(toROSPoint(p2));
+
+        return boost::make_shared<detail::InteractiveMarkerGraphHandle>(server_, interactive_marker);
+    }
+
+    GraphHandlePtr OpenRaveRviz::drawlinestrip_marker(float const *points, int num_points, int stride, float width, OpenRAVE::RaveVector<float> const &color)
+    {
+        visualization_msgs::InteractiveMarkerPtr interactive_marker = CreateMarker();
+        visualization_msgs::Marker &marker = interactive_marker->controls.front().markers.front();
+        marker.type = visualization_msgs::Marker::LINE_STRIP;
+        marker.color = toROSColor<>(color);
+        marker.scale.x = width;
+
+        ConvertPoints(points, num_points, stride, &marker.points);
+
+        return boost::make_shared<detail::InteractiveMarkerGraphHandle>(server_, interactive_marker);
+    }
+
+    GraphHandlePtr OpenRaveRviz::drawlinestrip_marker(float const *points, int num_points, int stride, float width, float const *colors)
+    {
+        visualization_msgs::InteractiveMarkerPtr interactive_marker = CreateMarker();
+        visualization_msgs::Marker &marker = interactive_marker->controls.front().markers.front();
+        marker.type = visualization_msgs::Marker::LINE_STRIP;
+        marker.scale.x = width;
+
+        ConvertPoints(points, num_points, stride, &marker.points);
+        ConvertColors(colors, num_points, false, &marker.colors);
+
+        return boost::make_shared<detail::InteractiveMarkerGraphHandle>(server_, interactive_marker);
+    }
+
+    GraphHandlePtr OpenRaveRviz::drawlinelist_marker(float const *points, int num_points, int stride, float width, OpenRAVE::RaveVector<float> const &color)
+    {
+        visualization_msgs::InteractiveMarkerPtr interactive_marker = CreateMarker();
+        visualization_msgs::Marker &marker = interactive_marker->controls.front().markers.front();
+        marker.type = visualization_msgs::Marker::LINE_LIST;
+        marker.color = toROSColor<>(color);
+        marker.scale.x = width / kWidthScaleFactor;
+
+        ConvertPoints(points, num_points, stride, &marker.points);
+
+        return boost::make_shared<detail::InteractiveMarkerGraphHandle>(server_, interactive_marker);
+    }
+
+    GraphHandlePtr OpenRaveRviz::drawlinelist_marker(float const *points, int num_points, int stride, float width, float const *colors)
+    {
+        visualization_msgs::InteractiveMarkerPtr interactive_marker = CreateMarker();
+        visualization_msgs::Marker &marker = interactive_marker->controls.front().markers.front();
+        marker.type = visualization_msgs::Marker::LINE_LIST;
+        marker.scale.x = width / kWidthScaleFactor;
+
+        ConvertPoints(points, num_points, stride, &marker.points);
+        ConvertColors(colors, num_points, false, &marker.colors);
+
+        return boost::make_shared<detail::InteractiveMarkerGraphHandle>(server_, interactive_marker);
+    }
+
+    GraphHandlePtr OpenRaveRviz::drawbox_marker(OpenRAVE::RaveVector<float> const &pos, OpenRAVE::RaveVector<float> const &extents)
+    {
+        visualization_msgs::InteractiveMarkerPtr interactive_marker = CreateMarker();
+        visualization_msgs::Marker &marker = interactive_marker->controls.front().markers.front();
+        marker.type = visualization_msgs::Marker::CUBE;
+        marker.pose.position = toROSPoint<>(pos);
+        marker.scale = toROSVector<>(2.0 * extents);
+
+        return boost::make_shared<detail::InteractiveMarkerGraphHandle>(server_, interactive_marker);
+    }
+
+    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawplane_marker(OpenRAVE::RaveTransform<float> const &transform, OpenRAVE::RaveVector<float> const &extents, boost::multi_array<float, 3> const &texture)
+    {
+        throw OpenRAVE::openrave_exception("drawplane is not implemented on InteractiveMarkerViewer", OpenRAVE::ORE_NotImplemented);
+    }
+
+    GraphHandlePtr OpenRaveRviz::drawtrimesh_marker(float const *points, int stride, int const *indices, int num_triangles, OpenRAVE::RaveVector<float> const &color)
+    {
+        visualization_msgs::InteractiveMarkerPtr interactive_marker = CreateMarker();
+        visualization_msgs::Marker &marker = interactive_marker->controls.front().markers.front();
+        marker.type = visualization_msgs::Marker::TRIANGLE_LIST;
+        marker.color = toROSColor<>(color);
+        marker.scale.x = 1;
+        marker.scale.y = 1;
+        marker.scale.z = 1;
+
+        ConvertMesh(points, stride, indices, num_triangles, &marker.points);
+
+        return boost::make_shared<detail::InteractiveMarkerGraphHandle>(server_, interactive_marker);
+    }
+
+    GraphHandlePtr OpenRaveRviz::drawtrimesh_marker(float const *points, int stride, int const *indices, int num_triangles, boost::multi_array<float, 2> const &colors)
+    {
+        visualization_msgs::InteractiveMarkerPtr interactive_marker = CreateMarker();
+        visualization_msgs::Marker &marker = interactive_marker->controls.front().markers.front();
+        marker.type = visualization_msgs::Marker::TRIANGLE_LIST;
+        marker.scale.x = 1;
+        marker.scale.y = 1;
+        marker.scale.z = 1;
+
+        ConvertMesh(points, stride, indices, num_triangles, &marker.points);
+
+        // TODO: Colors should be per-vertex, not per-face.
+        size_t const *color_shape = colors.shape();
+        if (color_shape[0] != num_triangles)
+        {
+            throw OpenRAVE::openrave_exception(boost::str(boost::format("Number of colors does not equal number of triangles;"
+                    " expected %d, got %d.") % color_shape[0] % num_triangles), OpenRAVE::ORE_InvalidArguments);
+        }
+        else if (color_shape[1] != 3 && color_shape[1] != 4)
+        {
+            throw OpenRAVE::openrave_exception(boost::str(boost::format("Invalid number of channels; expected 3 or 4, got %d.") % color_shape[1]), OpenRAVE::ORE_InvalidArguments);
+        }
+
+        marker.colors.resize(3 * num_triangles);
+        for (int itri = 0; itri < num_triangles; ++itri)
+        {
+            std_msgs::ColorRGBA color;
+            color.r = colors[itri][0];
+            color.g = colors[itri][1];
+            color.b = colors[itri][2];
+
+            if (color_shape[1] == 4)
+            {
+                color.a = colors[itri][3];
+            }
+            else
+            {
+                color.a = 1.0;
+            }
+
+            for (int ivertex = 0; ivertex < 3; ++ivertex)
+            {
+                int const index_offset = 3 * itri + ivertex;
+                int const index = stride * indices[index_offset];
+                marker.colors[index] = color;
+            }
+        }
+
+        return boost::make_shared<detail::InteractiveMarkerGraphHandle>(server_, interactive_marker);
+    }
+
 
     // Overloading OPENRAVE drawing functions....
     // Note: line width and point size are unsupported in Ogre
-    OpenRAVE::GraphHandlePtr OpenRaveRviz::plot3 (const float *ppoints, int numPoints, int stride, float fPointSize, const OpenRAVE::RaveVector< float > &color, int drawstyle)
+    OpenRAVE::GraphHandlePtr OpenRaveRviz::plot3_native (const float *ppoints, int numPoints, int stride, float fPointSize, const OpenRAVE::RaveVector< float > &color, int drawstyle)
     {
         if(numPoints <= 0)
         {
@@ -755,7 +1092,7 @@ namespace or_rviz
     }
 
     // Note: line width and point size are unsupported in Ogre
-    OpenRAVE::GraphHandlePtr OpenRaveRviz::plot3 (const float *ppoints, int numPoints, int stride, float fPointSize, const float *colors, int drawstyle, bool bhasalpha)
+    OpenRAVE::GraphHandlePtr OpenRaveRviz::plot3_native (const float *ppoints, int numPoints, int stride, float fPointSize, const float *colors, int drawstyle, bool bhasalpha)
     {
         if(numPoints <= 0)
         {
@@ -816,7 +1153,7 @@ namespace or_rviz
     }
 
     // Note: line width and point size are unsupported in Ogre
-    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawlinestrip (const float *ppoints, int numPoints, int stride, float fwidth, const OpenRAVE::RaveVector< float > &color)
+    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawlinestrip_native (const float *ppoints, int numPoints, int stride, float fwidth, const OpenRAVE::RaveVector< float > &color)
     {
         Ogre::SceneNode* sceneNode = m_envDisplay->GetNode()->createChildSceneNode();
 
@@ -862,7 +1199,7 @@ namespace or_rviz
         return ptr;
     }
 
-    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawlinestrip (const float *ppoints, int numPoints, int stride, float fwidth, const float *colors)
+    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawlinestrip_native (const float *ppoints, int numPoints, int stride, float fwidth, const float *colors)
     {
         Ogre::SceneNode* sceneNode = m_envDisplay->GetNode()->createChildSceneNode();
 
@@ -914,7 +1251,7 @@ namespace or_rviz
         return ptr;
     }
 
-    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawlinelist (const float *ppoints, int numPoints, int stride, float fwidth, const OpenRAVE::RaveVector< float > &color)
+    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawlinelist_native (const float *ppoints, int numPoints, int stride, float fwidth, const OpenRAVE::RaveVector< float > &color)
     {
         Ogre::SceneNode* sceneNode = m_envDisplay->GetNode()->createChildSceneNode();
 
@@ -950,7 +1287,7 @@ namespace or_rviz
         return ptr;
     }
 
-    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawlinelist (const float *ppoints, int numPoints, int stride, float fwidth, const float *colors)
+    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawlinelist_native (const float *ppoints, int numPoints, int stride, float fwidth, const float *colors)
     {
         Ogre::SceneNode* sceneNode = m_envDisplay->GetNode()->createChildSceneNode();
 
@@ -998,7 +1335,7 @@ namespace or_rviz
         return ptr;
     }
 
-    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawarrow (const OpenRAVE::RaveVector< float > &p1, const OpenRAVE::RaveVector< float > &p2, float fwidth, const OpenRAVE::RaveVector< float > &color)
+    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawarrow_native (const OpenRAVE::RaveVector< float > &p1, const OpenRAVE::RaveVector< float > &p2, float fwidth, const OpenRAVE::RaveVector< float > &color)
     {
         Ogre::SceneNode* sceneNode = m_envDisplay->GetNode()->createChildSceneNode();
 
@@ -1013,7 +1350,7 @@ namespace or_rviz
         return ptr;
     }
 
-    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawbox (const OpenRAVE::RaveVector< float > &vpos, const OpenRAVE::RaveVector< float > &vextents)
+    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawbox_native (const OpenRAVE::RaveVector< float > &vpos, const OpenRAVE::RaveVector< float > &vextents)
     {
         Ogre::SceneNode* sceneNode = m_envDisplay->GetNode()->createChildSceneNode();
         Ogre::ManualObject* cube = render_panel_->getManager()->getSceneManager()->createManualObject();
@@ -1101,24 +1438,18 @@ namespace or_rviz
         return ptr;
     }
 
-    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawplane (const OpenRAVE::RaveTransform< float > &tplane, const OpenRAVE::RaveVector< float > &vextents, const boost::multi_array< float, 3 > &vtexture)
+    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawplane_native (const OpenRAVE::RaveTransform< float > &tplane, const OpenRAVE::RaveVector< float > &vextents, const boost::multi_array< float, 3 > &vtexture)
     {
         RAVELOG_WARN("or_rviz does not yet support planes.\n");
         // This is not yet implemented
         return OpenRAVE::GraphHandlePtr();
     }
 
-    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawtrimesh (const float *ppoints, int stride, const int *pIndices, int numTriangles, const OpenRAVE::RaveVector< float > &color)
+    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawtrimesh_native (const float *ppoints, int stride, const int *pIndices, int numTriangles, const OpenRAVE::RaveVector< float > &color)
     {
         Ogre::SceneNode* sceneNode = m_envDisplay->GetNode()->createChildSceneNode();
         Ogre::ManualObject* manualObject = render_panel_->getManager()->getSceneManager()->createManualObject();
         manualObject->begin("BaseWhiteNoLighting", Ogre::RenderOperation::OT_TRIANGLE_LIST);
-
-
-        if(color.w < 1)
-        {
-            RAVELOG_WARN("or_rviz does not yet support alpha-blended trimeshes.\n");
-        }
 
         if (pIndices != NULL)
         {
@@ -1150,13 +1481,12 @@ namespace or_rviz
          return ptr;
     }
 
-    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawtrimesh (const float *ppoints, int stride, const int *pIndices, int numTriangles, const boost::multi_array< float, 2 > &colors)
+    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawtrimesh_native (const float *ppoints, int stride, const int *pIndices, int numTriangles, const boost::multi_array< float, 2 > &colors)
     {
 
         Ogre::SceneNode* sceneNode = m_envDisplay->GetNode()->createChildSceneNode();
         Ogre::ManualObject* manualObject = render_panel_->getManager()->getSceneManager()->createManualObject();
         manualObject->begin("BaseWhiteNoLighting", Ogre::RenderOperation::OT_TRIANGLE_LIST);
-
 
         if (pIndices != NULL)
         {
@@ -1179,26 +1509,217 @@ namespace or_rviz
                 manualObject->index(i);
             }
 
-
         }
-
 
          OpenRAVE::GraphHandlePtr ptr(new RvizGraphHandle(sceneNode, manualObject));
          m_graphsToInitialize.push_back(ptr);
          return ptr;
+    }
+
+    OpenRAVE::GraphHandlePtr OpenRaveRviz::plot3(const float *ppoints, int numPoints, int stride, float fPointSize, const OpenRAVE::RaveVector<float> &color, int drawstyle)
+    {
+        return plot3_marker(ppoints, numPoints, stride, fPointSize, color, drawstyle);
+    }
+
+    OpenRAVE::GraphHandlePtr OpenRaveRviz::plot3(const float *ppoints, int numPoints, int stride, float fPointSize, const float *colors, int drawstyle, bool bhasalpha)
+    {
+        return plot3_marker(ppoints, numPoints, stride, fPointSize, colors, drawstyle, bhasalpha);
+    }
+
+    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawlinestrip(const float *ppoints, int numPoints, int stride, float fwidth, const OpenRAVE::RaveVector<float> &color)
+    {
+        return drawlinestrip_marker(ppoints, numPoints, stride, fwidth, color);
+    }
+
+    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawlinestrip(const float *ppoints, int numPoints, int stride, float fwidth, const float *colors)
+    {
+        return drawlinestrip_marker(ppoints, numPoints, stride, fwidth, colors);
+    }
+
+    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawlinelist(const float *ppoints, int numPoints, int stride, float fwidth, const OpenRAVE::RaveVector<float> &color)
+    {
+        return drawlinelist_marker(ppoints, numPoints, stride, fwidth, color);
+    }
+
+    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawlinelist(const float *ppoints, int numPoints, int stride, float fwidth, const float *colors)
+    {
+        return drawlinelist_marker(ppoints, numPoints, stride, fwidth, colors);
+    }
+
+    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawarrow(const OpenRAVE::RaveVector<float> &p1, const OpenRAVE::RaveVector<float> &p2, float fwidth, const OpenRAVE::RaveVector<float> &color)
+    {
+        return drawarrow_marker(p1, p2, fwidth, color);
+    }
+
+    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawbox(const OpenRAVE::RaveVector<float> &vpos, const OpenRAVE::RaveVector<float> &vextents)
+    {
+        return drawbox_marker(vpos, vextents);
+    }
+
+    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawplane(const OpenRAVE::RaveTransform<float> &tplane, const OpenRAVE::RaveVector<float> &vextents, const boost::multi_array<float, 3> &vtexture)
+    {
+        return drawplane_marker(tplane, vextents, vtexture);
+    }
+
+    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawtrimesh(const float *ppoints, int stride, const int *pIndices, int numTriangles, const OpenRAVE::RaveVector<float> &color)
+    {
+        return drawtrimesh_marker(ppoints, stride, pIndices, numTriangles, color);
+    }
+
+    OpenRAVE::GraphHandlePtr OpenRaveRviz::drawtrimesh(const float *ppoints, int stride, const int *pIndices, int numTriangles, const boost::multi_array<float, 2> &colors)
+    {
+        return drawtrimesh_marker(ppoints, stride, pIndices, numTriangles, colors);
     }
 
     void OpenRaveRviz::Clear()
     {
-        m_envDisplay->Clear();
+        if(m_envDisplay)
+        {
+            m_envDisplay->Clear();
+        }
+
+        std::vector<KinBodyPtr> bodies;
+        GetCurrentViewEnv()->GetBodies(bodies);
+
+        for (KinBodyPtr body : bodies)
+        {
+           body->RemoveUserData("interactive_marker");
+        }
     }
 
     void OpenRaveRviz::syncUpdate()
     {
-        EnvironmentSync();
+        if(!running_) return;
+
+        if(do_sync_)
+        {
+            EnvironmentSync();
+        }
+        viewer_callbacks_();
     }
 
 
+    void OpenRaveRviz::KinBodyMenuCallback(OpenRAVE::KinBodyPtr kinbody, std::string const &name)
+    {
+        menu_queue_ << "kinbody " << kinbody->GetName() << " " << name << '\n';
+        selection_callbacks_(OpenRAVE::KinBody::LinkPtr(), OpenRAVE::RaveVector<float>(), OpenRAVE::RaveVector<float>());
+    }
+
+    void OpenRaveRviz::LinkMenuCallback(OpenRAVE::KinBody::LinkPtr link, std::string const &name)
+    {
+        menu_queue_ << "link " << link->GetParent()->GetName() << " " << link->GetName() << " " << name << '\n';
+    }
+
+    void OpenRaveRviz::ManipulatorMenuCallback(OpenRAVE::RobotBase::ManipulatorPtr manipulator, std::string const &name)
+    {
+        menu_queue_ << "manipulator " << manipulator->GetRobot()->GetName() << " " << manipulator->GetName() << " " << name << '\n';
+    }
+
+    visualization_msgs::InteractiveMarkerPtr OpenRaveRviz::CreateMarker() const
+    {
+        boost::shared_ptr<visualization_msgs::InteractiveMarker> interactive_marker = boost::make_shared<visualization_msgs::InteractiveMarker>();
+
+        interactive_marker->header.frame_id = manager_->getFixedFrame().toStdString();
+        interactive_marker->pose = or_interactivemarker::toROSPose(OpenRAVE::Transform());
+        interactive_marker->name = boost::str(boost::format("GraphHandle[%p]") % interactive_marker.get());
+        interactive_marker->scale = 1.0;
+
+        interactive_marker->controls.resize(1);
+        visualization_msgs::InteractiveMarkerControl &control = interactive_marker->controls.front();
+        control.orientation_mode = visualization_msgs::InteractiveMarkerControl::INHERIT;
+        control.interaction_mode = visualization_msgs::InteractiveMarkerControl::NONE;
+        control.always_visible = true;
+
+        control.markers.resize(1);
+        visualization_msgs::Marker &marker = control.markers.front();
+        marker.action = visualization_msgs::Marker::ADD;
+        marker.pose.orientation.w = 1.0;
+        marker.scale.x = 1.0;
+        marker.scale.y = 1.0;
+        marker.scale.z = 1.0;
+
+        return interactive_marker;
+    }
+
+    void OpenRaveRviz::ConvertPoints(float const *points, int num_points, int stride, std::vector<geometry_msgs::Point> *out_points) const
+    {
+        BOOST_ASSERT(points);
+        BOOST_ASSERT(num_points >= 0);
+        BOOST_ASSERT(stride >= 0 && stride % sizeof(float) == 0);
+        BOOST_ASSERT(out_points);
+
+        stride = stride / sizeof(float);
+
+        out_points->resize(num_points);
+        for (size_t ipoint = 0; ipoint < num_points; ++ipoint)
+        {
+            geometry_msgs::Point &out_point = out_points->at(ipoint);
+            out_point.x = points[stride * ipoint + 0];
+            out_point.y = points[stride * ipoint + 1];
+            out_point.z = points[stride * ipoint + 2];
+        }
+    }
+
+    void OpenRaveRviz::ConvertColors(float const *colors, int num_colors, bool has_alpha, std::vector<std_msgs::ColorRGBA> *out_colors) const
+    {
+        BOOST_ASSERT(colors);
+        BOOST_ASSERT(num_colors >= 0);
+        BOOST_ASSERT(out_colors);
+
+        int stride;
+        if (has_alpha)
+        {
+            stride = 4;
+        }
+        else
+        {
+            stride = 3;
+        }
+
+        out_colors->resize(num_colors);
+        for (size_t icolor = 0; icolor < num_colors; ++icolor)
+        {
+            std_msgs::ColorRGBA &out_color = out_colors->at(icolor);
+            out_color.r = colors[icolor * stride + 0];
+            out_color.g = colors[icolor * stride + 1];
+            out_color.b = colors[icolor * stride + 2];
+
+            if (has_alpha)
+            {
+                out_color.a = colors[icolor * stride + 3];
+            }
+            else
+            {
+                out_color.a = 1.0;
+            }
+        }
+    }
+
+    void OpenRaveRviz::ConvertMesh(float const *points, int stride, int const *indices, int num_triangles, std::vector<geometry_msgs::Point> *out_points) const
+    {
+        BOOST_ASSERT(points);
+        BOOST_ASSERT(stride > 0);
+        BOOST_ASSERT(indices);
+        BOOST_ASSERT(num_triangles >= 0);
+        BOOST_ASSERT(out_points);
+
+        auto const points_raw = reinterpret_cast<uint8_t const *>(points);
+
+        out_points->resize(3 * num_triangles);
+        for (int iindex = 0; iindex < num_triangles; ++iindex)
+        {
+            for (int ivertex = 0; ivertex < 3; ++ivertex)
+            {
+                int const index_offset = 3 * iindex + ivertex;
+                float const *or_point = reinterpret_cast<float const *>(points_raw + stride * indices[index_offset]);
+
+                geometry_msgs::Point &out_point = out_points->at(3 * iindex + ivertex);
+                out_point.x = or_point[0];
+                out_point.y = or_point[1];
+                out_point.z = or_point[2];
+            }
+        }
+    }
 
     RvizGraphHandle::RvizGraphHandle()
     {
@@ -1246,18 +1767,13 @@ namespace or_rviz
             manual->end();
             m_node->attachObject(m_object);
         }
-
     }
-
-
 }
 
 static char *argv[1] = { const_cast<char *>("or_rviz") };
 static int argc = 1;
 
-OpenRAVE::InterfaceBasePtr CreateInterfaceValidated(
-        OpenRAVE::InterfaceType type, std::string const& interfacename,
-        std::istream& sinput, OpenRAVE::EnvironmentBasePtr penv)
+OpenRAVE::InterfaceBasePtr CreateInterfaceValidated(OpenRAVE::InterfaceType type, std::string const& interfacename, std::istream& sinput, OpenRAVE::EnvironmentBasePtr penv)
 {
     if (type == OpenRAVE::PT_Viewer && interfacename == "or_rviz")
     {

--- a/src/OpenRaveRviz.cpp
+++ b/src/OpenRaveRviz.cpp
@@ -765,7 +765,6 @@ namespace or_rviz
     // Set the camera transformation.
     void OpenRaveRviz::SetCamera (const OpenRAVE::RaveTransform<float> &trans, float focalDistance)
     {
-        getManager()->getViewManager()->
         SetCamera(getManager()->getRenderPanel()->getCamera(), trans, focalDistance);
     }
 

--- a/src/or_conversions.cpp
+++ b/src/or_conversions.cpp
@@ -1,0 +1,116 @@
+#include "or_conversions.h"
+
+using OpenRAVE::dReal;
+using OpenRAVE::RaveVector;
+using OpenRAVE::RaveTransform;
+using std_msgs::ColorRGBA;
+using geometry_msgs::Vector3;
+using geometry_msgs::Pose;
+using geometry_msgs::Point;
+using geometry_msgs::Quaternion;
+
+namespace or_interactivemarker {
+
+/*
+ * OpenRAVE to ROS
+ */
+template <class Scalar>
+ColorRGBA toROSColor(RaveVector<Scalar> const &or_color)
+{
+    ColorRGBA color;
+    color.r = or_color.x;
+    color.g = or_color.y;
+    color.b = or_color.z;
+    color.a = or_color.w;
+    return color;
+}
+
+template <class Scalar>
+Vector3 toROSVector(RaveVector<Scalar> const &or_vector)
+{
+    Vector3 v;
+    v.x = or_vector.x;
+    v.y = or_vector.y;
+    v.z = or_vector.z;
+    return v;
+}
+
+template <class Scalar>
+Pose toROSPose(RaveTransform<Scalar> const &or_pose)
+{
+    Pose pose;
+    pose.position = toROSPoint<>(or_pose.trans);
+    pose.orientation = toROSQuaternion<>(or_pose.rot);
+    return pose;
+}
+
+template <class Scalar>
+Point toROSPoint(RaveVector<Scalar> const &or_point)
+{
+    Point point;
+    point.x = or_point.x;
+    point.y = or_point.y;
+    point.z = or_point.z;
+    return point;
+}
+
+template <class Scalar>
+Quaternion toROSQuaternion(RaveVector<Scalar> const &or_quat)
+{
+    Quaternion quaternion;
+    quaternion.w = or_quat[0];
+    quaternion.x = or_quat[1];
+    quaternion.y = or_quat[2];
+    quaternion.z = or_quat[3];
+    return quaternion;
+}
+
+/*
+ * ROS to OpenRAVE
+ */
+template <class Scalar>
+RaveVector<Scalar> toORPoint(Point const &point)
+{
+    return RaveVector<Scalar>(point.x, point.y, point.z);
+}
+
+template <class Scalar>
+RaveVector<Scalar> toORQuaternion(Quaternion const &quat)
+{
+    RaveVector<Scalar> or_quat;
+    or_quat[0] = quat.w;
+    or_quat[1] = quat.x;
+    or_quat[2] = quat.y;
+    or_quat[3] = quat.z;
+    return or_quat;
+}
+
+template <class Scalar>
+RaveTransform<Scalar> toORPose(Pose const &pose)
+{
+    RaveTransform<Scalar> or_transform;
+    or_transform.trans = toORPoint<Scalar>(pose.position);
+    or_transform.rot = toORQuaternion<Scalar>(pose.orientation);
+    return or_transform;
+}
+
+// Explicit instantiations.
+template ColorRGBA toROSColor<float>(RaveVector<float> const &color);
+template Vector3 toROSVector<float>(RaveVector<float> const &or_vector);
+template Pose toROSPose<float>(RaveTransform<float> const &or_pose);
+template Point toROSPoint<float>(RaveVector<float> const &or_point);
+template Quaternion toROSQuaternion<float>(RaveVector<float> const &or_point);
+template RaveVector<float> toORPoint(Point const &point);
+template RaveVector<float> toORQuaternion(Quaternion const &quat);
+template RaveTransform<float> toORPose(Pose const &pose);
+
+template ColorRGBA toROSColor<double>(RaveVector<double> const &color);
+template Vector3 toROSVector<double>(RaveVector<double> const &or_vector);
+template Pose toROSPose<double>(RaveTransform<double> const &or_pose);
+template Point toROSPoint<double>(RaveVector<double> const &or_point);
+template Quaternion toROSQuaternion<double>(RaveVector<double> const &or_point);
+template RaveVector<double> toORPoint(Point const &point);
+template RaveVector<double> toORQuaternion(Quaternion const &quat);
+template RaveTransform<double> toORPose(Pose const &pose);
+
+}

--- a/src/or_conversions.h
+++ b/src/or_conversions.h
@@ -1,0 +1,35 @@
+#ifndef ORCONVERSIONS_H_
+#define ORCONVERSIONS_H_
+#include <std_msgs/ColorRGBA.h>
+#include <geometry_msgs/Pose.h>
+#include <geometry_msgs/Point.h>
+#include <geometry_msgs/Quaternion.h>
+#include <geometry_msgs/Vector3.h>
+#include <openrave/openrave.h>
+
+namespace or_interactivemarker
+{
+
+// OpenRAVE to ROS
+    template<class Scalar>
+    std_msgs::ColorRGBA toROSColor(OpenRAVE::RaveVector<Scalar> const &color);
+    template<class Scalar>
+    geometry_msgs::Vector3 toROSVector(OpenRAVE::RaveVector<Scalar> const &or_vector);
+    template<class Scalar>
+    geometry_msgs::Pose toROSPose(OpenRAVE::RaveTransform<Scalar> const &or_pose);
+    template<class Scalar>
+    geometry_msgs::Point toROSPoint(OpenRAVE::RaveVector<Scalar> const &or_point);
+    template<class Scalar>
+    geometry_msgs::Quaternion toROSQuaternion(OpenRAVE::RaveVector<Scalar> const &or_quat);
+
+// ROS to OpenRAVE
+    template<class Scalar>
+    OpenRAVE::RaveVector<Scalar> toORPoint(geometry_msgs::Point const &point);
+    template<class Scalar>
+    OpenRAVE::RaveVector<Scalar> toORQuaternion(geometry_msgs::Quaternion const &quat);
+    template<class Scalar>
+    OpenRAVE::RaveTransform<Scalar> toORPose(geometry_msgs::Pose const &pose);
+
+}
+
+#endif


### PR DESCRIPTION
Merges or_interactivemarker with or_rviz to make one new viewer.

* Uses or_interactivemarker classes for rendering and interacting with kinbodies and plots
* Uses or_rviz code for creating the window, controlling the background color, controlling the camera, lighting, and switching between environments
* Old or_rviz rendering and plotting code is still around but commented out or not used.