### PR TITLE
Hack to avoid crashing with a NULL IK solver (#3)

### DIFF
--- a/src/ManipulatorMarker.cpp
+++ b/src/ManipulatorMarker.cpp
@@ -129,6 +129,11 @@ bool ManipulatorMarker::EnvironmentSync()
     IkSolverBasePtr const ik_solver = manipulator->GetIkSolver();
     RobotStateSaver const saver(robot, KinBody::Save_LinkTransformation);
 
+    // Hack to avoid crashing if no IK solver is set.
+    if (!ik_solver) {
+        return false;
+    }
+
     // Figure out what the free joints are.
     size_t const num_free = ik_solver->GetNumFreeParameters();
     std::vector<JointPtr> free_joints;


### PR DESCRIPTION
This is a quick fix for #3.

To do this properly, I need to:
- Not create a `ManipulatorMarker` if no IK solver is set.
- Re-create the `ManipulatorMarker` if the IK solver changes.
- Hide the menu option if the marker is disabled.
