### PR TITLE
Changed cylinder radius to match InteractiveMarker spec.

### DIFF
--- a/src/markers/LinkMarker.cpp
+++ b/src/markers/LinkMarker.cpp
@@ -380,8 +380,8 @@ MarkerPtr LinkMarker::CreateCollisionGeometry(GeometryPtr geometry)
         double const cylinder_radius = geometry->GetCylinderRadius();
         double const cylinder_height= geometry->GetCylinderHeight();
         marker->type = Marker::CYLINDER;
-        marker->scale.x = 0.5 * cylinder_radius;
-        marker->scale.y = 0.5 * cylinder_radius;
+        marker->scale.x = 2.0 * cylinder_radius;
+        marker->scale.y = 2.0 * cylinder_radius;
         marker->scale.z = cylinder_height;
         break;
     }


### PR DESCRIPTION
Currently, cylinder primitives are rendered at one fourth their normal diameter due to a bug in the conversion to an interactive marker.  This PR changes the scaling to match the InteractiveMarker spec.

From http://wiki.ros.org/rviz/DisplayTypes/Marker#Cylinder_.28CYLINDER.3D3.29

> scale.x is diameter in x direction, scale.y in y direction, by setting these to different values you get an ellipse instead of a circle. Use scale.z to specify the height.
