### PR TITLE
Add incude guards as workaround for Qt Moc bug

### DIFF
--- a/include/or_rviz/InteractiveMarkerViewer.h
+++ b/include/or_rviz/InteractiveMarkerViewer.h
@@ -33,7 +33,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define ORINTERACTIVEMARKER_H_
 #include <boost/unordered_map.hpp>
 #include <boost/signals2.hpp>
-#include <openrave/openrave.h>
+// workaround for qt moc bug w.r.t. BOOST_JOIN macro
+// see https://bugreports.qt.io/browse/QTBUG-22829
+#ifndef Q_MOC_RUN
+# include <openrave/openrave.h>
+#endif
 #include <interactive_markers/interactive_marker_server.h>
 #include "markers/KinBodyMarker.h"
 #include "util/InteractiveMarkerGraphHandle.h"

--- a/include/or_rviz/InteractiveMarkerViewer.h
+++ b/include/or_rviz/InteractiveMarkerViewer.h
@@ -36,7 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // workaround for qt moc bug w.r.t. BOOST_JOIN macro
 // see https://bugreports.qt.io/browse/QTBUG-22829
 #ifndef Q_MOC_RUN
-# include <openrave/openrave.h>
+    #include <openrave/openrave.h>
 #endif
 #include <interactive_markers/interactive_marker_server.h>
 #include "markers/KinBodyMarker.h"

--- a/include/or_rviz/markers/JointMarker.h
+++ b/include/or_rviz/markers/JointMarker.h
@@ -31,7 +31,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *************************************************************************/
 #ifndef JOINTMARKER_H_
 #define JOINTMARKER_H_
-#include <openrave/openrave.h>
+// workaround for qt moc bug w.r.t. BOOST_JOIN macro
+// see https://bugreports.qt.io/browse/QTBUG-22829
+#ifndef Q_MOC_RUN
+# include <openrave/openrave.h>
+#endif
 #include <interactive_markers/interactive_marker_server.h>
 
 namespace or_rviz {

--- a/include/or_rviz/markers/JointMarker.h
+++ b/include/or_rviz/markers/JointMarker.h
@@ -34,7 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // workaround for qt moc bug w.r.t. BOOST_JOIN macro
 // see https://bugreports.qt.io/browse/QTBUG-22829
 #ifndef Q_MOC_RUN
-# include <openrave/openrave.h>
+    #include <openrave/openrave.h>
 #endif
 #include <interactive_markers/interactive_marker_server.h>
 

--- a/include/or_rviz/markers/KinBodyJointMarker.h
+++ b/include/or_rviz/markers/KinBodyJointMarker.h
@@ -34,7 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // workaround for qt moc bug w.r.t. BOOST_JOIN macro
 // see https://bugreports.qt.io/browse/QTBUG-22829
 #ifndef Q_MOC_RUN
-# include <openrave/openrave.h>
+    #include <openrave/openrave.h>
 #endif
 #include <interactive_markers/interactive_marker_server.h>
 #include "JointMarker.h"

--- a/include/or_rviz/markers/KinBodyJointMarker.h
+++ b/include/or_rviz/markers/KinBodyJointMarker.h
@@ -31,7 +31,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *************************************************************************/
 #ifndef KINBODYJOINTMARKER_H_
 #define KINBODYJOINTMARKER_H_
-#include <openrave/openrave.h>
+// workaround for qt moc bug w.r.t. BOOST_JOIN macro
+// see https://bugreports.qt.io/browse/QTBUG-22829
+#ifndef Q_MOC_RUN
+# include <openrave/openrave.h>
+#endif
 #include <interactive_markers/interactive_marker_server.h>
 #include "JointMarker.h"
 

--- a/include/or_rviz/markers/KinBodyMarker.h
+++ b/include/or_rviz/markers/KinBodyMarker.h
@@ -38,7 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // workaround for qt moc bug w.r.t. BOOST_JOIN macro
 // see https://bugreports.qt.io/browse/QTBUG-22829
 #ifndef Q_MOC_RUN
-# include <openrave/openrave.h>
+    #include <openrave/openrave.h>
 #endif
 #include "KinBodyLinkMarker.h"
 #include "KinBodyJointMarker.h"

--- a/include/or_rviz/markers/KinBodyMarker.h
+++ b/include/or_rviz/markers/KinBodyMarker.h
@@ -35,7 +35,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <boost/unordered_set.hpp>
 #include <boost/optional.hpp>
 #include <boost/shared_ptr.hpp>
-#include <openrave/openrave.h>
+// workaround for qt moc bug w.r.t. BOOST_JOIN macro
+// see https://bugreports.qt.io/browse/QTBUG-22829
+#ifndef Q_MOC_RUN
+# include <openrave/openrave.h>
+#endif
 #include "KinBodyLinkMarker.h"
 #include "KinBodyJointMarker.h"
 #include "ManipulatorMarker.h"

--- a/include/or_rviz/markers/LinkMarker.h
+++ b/include/or_rviz/markers/LinkMarker.h
@@ -38,7 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // workaround for qt moc bug w.r.t. BOOST_JOIN macro
 // see https://bugreports.qt.io/browse/QTBUG-22829
 #ifndef Q_MOC_RUN
-# include <openrave/openrave.h>
+    #include <openrave/openrave.h>
 #endif
 #include <visualization_msgs/InteractiveMarker.h>
 #include <interactive_markers/menu_handler.h>

--- a/include/or_rviz/markers/LinkMarker.h
+++ b/include/or_rviz/markers/LinkMarker.h
@@ -35,7 +35,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <boost/optional.hpp>
 #include <boost/unordered_map.hpp>
 #include <boost/shared_ptr.hpp>
-#include <openrave/openrave.h>
+// workaround for qt moc bug w.r.t. BOOST_JOIN macro
+// see https://bugreports.qt.io/browse/QTBUG-22829
+#ifndef Q_MOC_RUN
+# include <openrave/openrave.h>
+#endif
 #include <visualization_msgs/InteractiveMarker.h>
 #include <interactive_markers/menu_handler.h>
 #include <interactive_markers/interactive_marker_server.h>

--- a/include/or_rviz/markers/ManipulatorMarker.h
+++ b/include/or_rviz/markers/ManipulatorMarker.h
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // workaround for qt moc bug w.r.t. BOOST_JOIN macro
 // see https://bugreports.qt.io/browse/QTBUG-22829
 #ifndef Q_MOC_RUN
-# include <openrave/openrave.h>
+    #include <openrave/openrave.h>
 #endif
 #include <interactive_markers/interactive_marker_server.h>
 #include "LinkMarker.h"

--- a/include/or_rviz/markers/ManipulatorMarker.h
+++ b/include/or_rviz/markers/ManipulatorMarker.h
@@ -32,7 +32,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef MANIPULATORMARKER_H_
 #define MANIPULATORMARKER_H_
 #include <boost/unordered_map.hpp>
-#include <openrave/openrave.h>
+// workaround for qt moc bug w.r.t. BOOST_JOIN macro
+// see https://bugreports.qt.io/browse/QTBUG-22829
+#ifndef Q_MOC_RUN
+# include <openrave/openrave.h>
+#endif
 #include <interactive_markers/interactive_marker_server.h>
 #include "LinkMarker.h"
 #include "JointMarker.h"

--- a/include/or_rviz/rviz/EnvironmentDisplay.h
+++ b/include/or_rviz/rviz/EnvironmentDisplay.h
@@ -41,7 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // workaround for qt moc bug w.r.t. BOOST_JOIN macro
 // see https://bugreports.qt.io/browse/QTBUG-22829
 #ifndef Q_MOC_RUN
-# include <openrave/openrave.h>
+    #include <openrave/openrave.h>
 #endif
 
 namespace or_rviz {

--- a/include/or_rviz/rviz/EnvironmentDisplay.h
+++ b/include/or_rviz/rviz/EnvironmentDisplay.h
@@ -38,7 +38,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rviz/display.h>
 #include <rviz/properties/enum_property.h>
 #include <rviz/properties/tf_frame_property.h>
-#include <openrave/openrave.h>
+// workaround for qt moc bug w.r.t. BOOST_JOIN macro
+// see https://bugreports.qt.io/browse/QTBUG-22829
+#ifndef Q_MOC_RUN
+# include <openrave/openrave.h>
+#endif
 
 namespace or_rviz {
 namespace rviz {

--- a/include/or_rviz/rviz/KinBodyVisual.h
+++ b/include/or_rviz/rviz/KinBodyVisual.h
@@ -35,8 +35,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // workaround for qt moc bug w.r.t. BOOST_JOIN macro
 // see https://bugreports.qt.io/browse/QTBUG-22829
 #ifndef Q_MOC_RUN
-# include <openrave/openrave.h>
-# include <openrave/kinbody.h>
+    #include <openrave/openrave.h>
+    #include <openrave/kinbody.h>
 #endif
 #include <vector>
 #include <rviz/properties/property.h>

--- a/include/or_rviz/rviz/KinBodyVisual.h
+++ b/include/or_rviz/rviz/KinBodyVisual.h
@@ -32,8 +32,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef KINBODYVISUAL_H_
 #define KINBODYVISUAL_H_
 
-#include <openrave/openrave.h>
-#include <openrave/kinbody.h>
+// workaround for qt moc bug w.r.t. BOOST_JOIN macro
+// see https://bugreports.qt.io/browse/QTBUG-22829
+#ifndef Q_MOC_RUN
+# include <openrave/openrave.h>
+# include <openrave/kinbody.h>
+#endif
 #include <vector>
 #include <rviz/properties/property.h>
 #include <rviz/properties/bool_property.h>

--- a/include/or_rviz/rviz/LinkVisual.h
+++ b/include/or_rviz/rviz/LinkVisual.h
@@ -36,8 +36,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // workaround for qt moc bug w.r.t. BOOST_JOIN macro
 // see https://bugreports.qt.io/browse/QTBUG-22829
 #ifndef Q_MOC_RUN
-# include <openrave/openrave.h>
-# include <openrave/kinbody.h>
+    #include <openrave/openrave.h>
+    #include <openrave/kinbody.h>
 #endif
 #include <vector>
 #include "Ogre.h"

--- a/include/or_rviz/rviz/LinkVisual.h
+++ b/include/or_rviz/rviz/LinkVisual.h
@@ -33,8 +33,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define LINKVISUAL_H_
 
 #include <rviz/properties/property.h>
-#include <openrave/openrave.h>
-#include <openrave/kinbody.h>
+// workaround for qt moc bug w.r.t. BOOST_JOIN macro
+// see https://bugreports.qt.io/browse/QTBUG-22829
+#ifndef Q_MOC_RUN
+# include <openrave/openrave.h>
+# include <openrave/kinbody.h>
+#endif
 #include <vector>
 #include "Ogre.h"
 

--- a/include/or_rviz/util/InteractiveMarkerGraphHandle.h
+++ b/include/or_rviz/util/InteractiveMarkerGraphHandle.h
@@ -1,7 +1,11 @@
 #ifndef INTERACTIVEMARKERGRAPHHANDLE_H_
 #define INTERACTIVEMARKERGRAPHHANDLE_H_
 #include <boost/function.hpp>
-#include <openrave/openrave.h>
+// workaround for qt moc bug w.r.t. BOOST_JOIN macro
+// see https://bugreports.qt.io/browse/QTBUG-22829
+#ifndef Q_MOC_RUN
+# include <openrave/openrave.h>
+#endif
 #include <interactive_markers/interactive_marker_server.h>
 
 namespace or_rviz {

--- a/include/or_rviz/util/InteractiveMarkerGraphHandle.h
+++ b/include/or_rviz/util/InteractiveMarkerGraphHandle.h
@@ -4,7 +4,7 @@
 // workaround for qt moc bug w.r.t. BOOST_JOIN macro
 // see https://bugreports.qt.io/browse/QTBUG-22829
 #ifndef Q_MOC_RUN
-# include <openrave/openrave.h>
+    #include <openrave/openrave.h>
 #endif
 #include <interactive_markers/interactive_marker_server.h>
 

--- a/include/or_rviz/util/ScopedConnection.h
+++ b/include/or_rviz/util/ScopedConnection.h
@@ -1,7 +1,11 @@
 #ifndef SCOPEDCONNECTION_H_
 #define SCOPEDCONNECTION_H_
 #include <boost/signals2.hpp>
-#include <openrave/openrave.h>
+// workaround for qt moc bug w.r.t. BOOST_JOIN macro
+// see https://bugreports.qt.io/browse/QTBUG-22829
+#ifndef Q_MOC_RUN
+# include <openrave/openrave.h>
+#endif
 
 namespace or_rviz {
 namespace util {

--- a/include/or_rviz/util/ScopedConnection.h
+++ b/include/or_rviz/util/ScopedConnection.h
@@ -4,7 +4,7 @@
 // workaround for qt moc bug w.r.t. BOOST_JOIN macro
 // see https://bugreports.qt.io/browse/QTBUG-22829
 #ifndef Q_MOC_RUN
-# include <openrave/openrave.h>
+    #include <openrave/openrave.h>
 #endif
 
 namespace or_rviz {

--- a/include/or_rviz/util/ros_conversions.h
+++ b/include/or_rviz/util/ros_conversions.h
@@ -36,7 +36,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <geometry_msgs/Point.h>
 #include <geometry_msgs/Quaternion.h>
 #include <geometry_msgs/Vector3.h>
-#include <openrave/openrave.h>
+// workaround for qt moc bug w.r.t. BOOST_JOIN macro
+// see https://bugreports.qt.io/browse/QTBUG-22829
+#ifndef Q_MOC_RUN
+# include <openrave/openrave.h>
+#endif
 
 namespace or_rviz {
 namespace util {

--- a/include/or_rviz/util/ros_conversions.h
+++ b/include/or_rviz/util/ros_conversions.h
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // workaround for qt moc bug w.r.t. BOOST_JOIN macro
 // see https://bugreports.qt.io/browse/QTBUG-22829
 #ifndef Q_MOC_RUN
-# include <openrave/openrave.h>
+    #include <openrave/openrave.h>
 #endif
 
 namespace or_rviz {


### PR DESCRIPTION
On my system, `or_rviz` fails to compile with:

```
usr/include/boost/type_traits/detail/has_binary_operator.hp:50: Parse error at "BOOST_JOIN"
```

This is a known bug with Qt Moc (see [0]) before Qt 5.0 that apparently affects class definitions that include some version of boost's BOOST_JOIN macro.  This apparently includes my system.  I'm using the latest OpenRAVE, Qt 4.8, and Boost 1.49.0 on Debian Wheezy.

I was able to fix the issue on my system by applying the suggested workaround from the linked bug report.  This PR adds the workaround.

[0] https://bugreports.qt.io/browse/QTBUG-22829
