### PR TITLE
Adds function to change the frame IDs of published markers.

### DIFF
--- a/include/or_rviz/InteractiveMarkerViewer.h
+++ b/include/or_rviz/InteractiveMarkerViewer.h
@@ -151,6 +151,8 @@ private:
 
     bool AddMenuEntryCommand(std::ostream &out, std::istream &in);
     bool GetMenuSelectionCommand(std::ostream &out, std::istream &in);
+    bool SetFrameIdCommand(std::ostream &out, std::istream &in);
+    bool GetFrameIdCommand(std::ostream &out, std::istream &in);
 
     void GraphHandleRemovedCallback(util::InteractiveMarkerGraphHandle *handle);
     void BodyCallback(OpenRAVE::KinBodyPtr kinbody, int flag);


### PR DESCRIPTION
We actually already seemed to have this functionality, but just didn't expose it over Python, so I'm adding the helpers to do that.